### PR TITLE
Fix: downloaded ZIP is never saved (offscreen document has no chrome.downloads)

### DIFF
--- a/background.js
+++ b/background.js
@@ -204,6 +204,30 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     return true;
   }
 
+  // The offscreen document builds the ZIP blob but has no chrome.downloads,
+  // so it hands the blob URL here for the actual save.
+  if (msg.action === "saveZip") {
+    chrome.downloads.download(
+      {
+        url: msg.url,
+        filename: msg.filename || "sketchfab-model.zip",
+        saveAs: true,
+      },
+      (downloadId) => {
+        const err = chrome.runtime.lastError;
+        if (err || downloadId === undefined || downloadId === null) {
+          const message = (err && err.message) || "chrome.downloads.download returned no id";
+          devLog("error", "Save failed", { message });
+          sendResponse({ ok: false, error: message });
+          return;
+        }
+        devLog("info", "Save started", { downloadId, filename: msg.filename });
+        sendResponse({ ok: true, downloadId });
+      }
+    );
+    return true;
+  }
+
   if (msg.action === "getDevMode") {
     isDevMode().then((on) => sendResponse({ ok: true, devMode: on }));
     return true;

--- a/offscreen/offscreen.js
+++ b/offscreen/offscreen.js
@@ -3,12 +3,51 @@
  * Service workers are killed on 4K texture packs (40+ maps × 64 MB RGBA).
  */
 import { downloadModel } from "../lib/pipeline.js";
-import { saveZip } from "../lib/save.js";
 
 function emit(msg) {
   try {
     chrome.runtime.sendMessage({ source: "sf-offscreen", ...msg });
   } catch (_) {}
+}
+
+/**
+ * Offscreen documents only get chrome.runtime — chrome.downloads is undefined
+ * here, so lib/save.js silently fell back to clicking an <a download> in a
+ * hidden, gesture-less document, which never saves anything.
+ *
+ * Build the blob URL here (we have a DOM) and let the service worker, which
+ * does have chrome.downloads, perform the save. The URL is same-origin, so
+ * only a short string crosses the message boundary.
+ *
+ * @param {Uint8Array} zip
+ * @param {string} filename
+ * @returns {Promise<number>} download id
+ */
+async function saveViaServiceWorker(zip, filename) {
+  const blob = new Blob([zip], { type: "application/zip" });
+  const url = URL.createObjectURL(blob);
+  let res;
+  try {
+    res = await chrome.runtime.sendMessage({ action: "saveZip", url, filename });
+  } catch (e) {
+    try {
+      URL.revokeObjectURL(url);
+    } catch (_) {}
+    throw e;
+  }
+  if (!res || !res.ok) {
+    try {
+      URL.revokeObjectURL(url);
+    } catch (_) {}
+    throw new Error((res && res.error) || "Service worker could not save the ZIP");
+  }
+  // Keep the blob alive until the Save As dialog is answered and the write starts.
+  setTimeout(() => {
+    try {
+      URL.revokeObjectURL(url);
+    } catch (_) {}
+  }, 120_000);
+  return res.downloadId;
 }
 
 async function runDownload(payload) {
@@ -46,7 +85,7 @@ async function runDownload(payload) {
     type: "progress",
     text: `Saving ${result.zipName} (${zip.length} bytes)…`,
   });
-  await saveZip(zip, result.zipName);
+  const downloadId = await saveViaServiceWorker(zip, result.zipName);
   return {
     zipName: result.zipName,
     name: result.name,
@@ -54,6 +93,7 @@ async function runDownload(payload) {
     hasGlb: !!result.hasGlb,
     fileCount: result.fileCount || 0,
     zipBytes: zip.length,
+    downloadId,
     saved: true,
   };
 }


### PR DESCRIPTION
## Problem

Clicking **Download glTF ZIP** builds the model correctly, but no file is ever written. The panel still reports `✅ Done: <name> by <author> (N bytes)`, so it looks like a successful download that silently produced nothing.

## Cause

After building the ZIP, `offscreen/offscreen.js` calls `saveZip()` from `lib/save.js`. That function gates on:

```js
if (typeof chrome !== "undefined" && chrome.downloads && chrome.downloads.download) {
```

Offscreen documents only expose `chrome.runtime`, so `chrome.downloads` is `undefined` there. Execution falls through to the `<a download>` fallback at the bottom of `save.js` — an anchor click inside a hidden document with no user gesture, which never saves a file.

That fallback doesn't throw, so `runDownload()` returns `saved: true` regardless. Three consequences follow:

- the panel reports success for a file that does not exist
- `result.downloadId` is always `undefined` (forwarded at `background.js:157`)
- because `saved` is true, `content/panel.js:749` skips its own client-side save fallback, so the last chance to write the file is also lost

## Fix

Build the blob URL in the offscreen document (which has a DOM) and hand it to the service worker, which does have `chrome.downloads`. Only a short URL string crosses the message boundary, so large texture packs are unaffected.

Save failures now reject instead of reporting success, so the panel shows a real error — including when the Save As dialog is cancelled — rather than a false ✅. `downloadId` is now a real id.

## Testing

- Verified on a public model: the Save As dialog appears and the ZIP is written to disk. Same model produced no file before the change.
- `npm test` — 23/23 pass.
- `node --check` clean on both changed files.

To confirm the cause directly: `chrome://extensions` → the extension → **Inspect views: offscreen.html** → evaluate `chrome.downloads` in that console. It is `undefined`, which is why the original call could never have reached the downloads API.

## Note, not addressed here

`lib/save-sw.js` (`saveZipInServiceWorker`) isn't imported anywhere in the tree — it looks like it was written for exactly this path and left unwired. I left it untouched to keep this change focused. Happy to remove it, or to switch the save over to its `data:`-URL approach instead, if you'd prefer either.
