### PR TITLE
Fix three material-export bugs: ORM packing, false BLEND, dropped glass

### DIFF
--- a/lib/orm.js
+++ b/lib/orm.js
@@ -1,0 +1,196 @@
+/**
+ * Pack Sketchfab's separate metalness / roughness maps into one glTF
+ * metallicRoughness texture (glTF: G = roughness, B = metalness).
+ *
+ * Sketchfab serves MetalnessPBR and RoughnessPBR as independent grayscale
+ * maps. Binding the metalness map straight into metallicRoughnessTexture
+ * makes its green channel drive roughness, so a black (non-metal) map reads
+ * as roughness 0 and every surface turns into a mirror.
+ *
+ * The pixel math here is deliberately free of DOM APIs so it can be unit
+ * tested under `node --test`; decoding/encoding lives in packOrmTexture().
+ */
+
+/** @param {string} filename */
+function baseName(filename) {
+  return String(filename || "")
+    .split("/")
+    .pop()
+    .split("?")[0];
+}
+
+/** @param {string} filename */
+function stemOf(filename) {
+  return baseName(filename)
+    .replace(/\.[^.]+$/, "")
+    .toLowerCase();
+}
+
+/**
+ * True when a filename denotes an already-packed ORM/MRAO texture, as opposed
+ * to a single-channel `*_metallic` / `*_roughness` map.
+ *
+ * classifyTextureName() answers 'metalrough' for both, which is why binding on
+ * that alone is not safe.
+ *
+ * @param {string} filename
+ * @returns {boolean}
+ */
+export function isPackedOrmName(filename) {
+  const stem = stemOf(filename);
+  if (!stem) return false;
+  const packed = stem.replace(/[^a-z0-9]+/g, "");
+  if (/metallicroughness|metalroughness|metalrough|mrao|occlusionroughnessmetallic/.test(packed)) {
+    return true;
+  }
+  return /(?:^|[_-])(orm|rma|arm)(?:[_-]|$)/.test(stem);
+}
+
+/**
+ * Decide how a material's metal/rough channels should reach glTF.
+ *
+ * @param {object} spec - viewer material spec (see parseViewerMaterials)
+ * @param {(uid: string) => (string|null)} resolve - uid -> texture basename
+ * @param {(name: string) => string} [classify] - optional name classifier
+ * @returns {{action: 'passthrough'|'pack'|'factors', texture?: string,
+ *            metalName?: string|null, roughName?: string|null,
+ *            invertRough?: boolean, reason: string}}
+ */
+export function planOrm(spec, resolve, classify) {
+  const res = typeof resolve === "function" ? resolve : () => null;
+  let metalName = spec && spec.metalnessUid ? res(spec.metalnessUid) : null;
+  const roughName = spec && spec.roughnessUid ? res(spec.roughnessUid) : null;
+
+  // Sketchfab sometimes points MetalnessPBR at a colour/id map, not a mask.
+  if (metalName && typeof classify === "function" && classify(metalName) === "albedo") {
+    metalName = null;
+  }
+
+  if (metalName && !roughName && isPackedOrmName(metalName)) {
+    return { action: "passthrough", texture: metalName, reason: "already-packed ORM" };
+  }
+
+  if (metalName || roughName) {
+    return {
+      action: "pack",
+      metalName: metalName || null,
+      roughName: roughName || null,
+      // roughnessUid falls back to GlossinessPBR, which is inverted roughness.
+      invertRough: !!(spec && spec.roughnessIsGloss && roughName),
+      reason: metalName && roughName ? "separate metal + rough" : metalName ? "metal only" : "rough only",
+    };
+  }
+
+  return { action: "factors", reason: "no metal/rough maps" };
+}
+
+/**
+ * Compose the ORM pixel buffer.
+ *
+ * Channels follow the glTF spec: R is free (occlusion), G roughness,
+ * B metalness. Grayscale sources carry the same value in every channel, so
+ * the red channel is read as the source value.
+ *
+ * @param {{metal?: Uint8Array|Uint8ClampedArray|null,
+ *          rough?: Uint8Array|Uint8ClampedArray|null,
+ *          ao?: Uint8Array|Uint8ClampedArray|null,
+ *          width: number, height: number,
+ *          invertRough?: boolean,
+ *          metalFallback?: number, roughFallback?: number}} opts
+ * @returns {Uint8ClampedArray} RGBA pixels
+ */
+export function packOrmPixels(opts) {
+  const { width, height } = opts;
+  const n = width * height;
+  if (!(n > 0)) throw new Error("packOrmPixels: bad dimensions");
+
+  const metal = opts.metal || null;
+  const rough = opts.rough || null;
+  const ao = opts.ao || null;
+  const invert = !!opts.invertRough;
+  // Non-metal and fairly rough is the safe default for a missing channel.
+  const metalFallback = clamp255(opts.metalFallback != null ? opts.metalFallback : 0);
+  const roughFallback = clamp255(opts.roughFallback != null ? opts.roughFallback : 229);
+
+  const out = new Uint8ClampedArray(n * 4);
+  for (let i = 0; i < n; i++) {
+    const p = i * 4;
+    const r = rough ? rough[p] : roughFallback;
+    out[p] = ao ? ao[p] : 255;
+    out[p + 1] = invert ? 255 - r : r;
+    out[p + 2] = metal ? metal[p] : metalFallback;
+    out[p + 3] = 255;
+  }
+  return out;
+}
+
+function clamp255(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 0;
+  return n < 0 ? 0 : n > 255 ? 255 : n | 0;
+}
+
+/**
+ * Decode source maps, resample to a common size and encode a packed ORM PNG.
+ * Requires createImageBitmap + OffscreenCanvas (offscreen document / worker).
+ *
+ * @param {{metal?: {data: Uint8Array}|null, rough?: {data: Uint8Array}|null,
+ *          ao?: {data: Uint8Array}|null, invertRough?: boolean,
+ *          maxEdge?: number}} sources
+ * @returns {Promise<{data: Uint8Array, width: number, height: number}>}
+ */
+export async function packOrmTexture(sources) {
+  if (typeof createImageBitmap !== "function" || typeof OffscreenCanvas !== "function") {
+    throw new Error("ORM packing needs createImageBitmap + OffscreenCanvas");
+  }
+  const metalBmp = await decode(sources.metal);
+  const roughBmp = await decode(sources.rough);
+  if (!metalBmp && !roughBmp) throw new Error("ORM packing: no source maps");
+
+  const cap = sources.maxEdge && sources.maxEdge > 0 ? sources.maxEdge : Infinity;
+  const width = Math.max(1, Math.min(cap, Math.max(dim(metalBmp, "width"), dim(roughBmp, "width"))));
+  const height = Math.max(1, Math.min(cap, Math.max(dim(metalBmp, "height"), dim(roughBmp, "height"))));
+
+  const packed = packOrmPixels({
+    metal: metalBmp ? resample(metalBmp, width, height) : null,
+    rough: roughBmp ? resample(roughBmp, width, height) : null,
+    width,
+    height,
+    invertRough: !!sources.invertRough,
+  });
+
+  const canvas = new OffscreenCanvas(width, height);
+  const ctx = canvas.getContext("2d");
+  ctx.putImageData(new ImageData(packed, width, height), 0, 0);
+  const blob = await canvas.convertToBlob({ type: "image/png" });
+  const data = new Uint8Array(await blob.arrayBuffer());
+  closeBmp(metalBmp);
+  closeBmp(roughBmp);
+  return { data, width, height };
+}
+
+function dim(bmp, key) {
+  return bmp ? bmp[key] || 0 : 0;
+}
+
+function closeBmp(bmp) {
+  try {
+    if (bmp && bmp.close) bmp.close();
+  } catch (_) {}
+}
+
+async function decode(entry) {
+  if (!entry || !entry.data || !entry.data.length) return null;
+  try {
+    return await createImageBitmap(new Blob([entry.data]));
+  } catch (_) {
+    return null;
+  }
+}
+
+function resample(bmp, width, height) {
+  const canvas = new OffscreenCanvas(width, height);
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  ctx.drawImage(bmp, 0, 0, width, height);
+  return ctx.getImageData(0, 0, width, height).data;
+}

--- a/lib/orm.js
+++ b/lib/orm.js
@@ -43,7 +43,11 @@ export function isPackedOrmName(filename) {
   if (/metallicroughness|metalroughness|metalrough|mrao|occlusionroughnessmetallic/.test(packed)) {
     return true;
   }
-  return /(?:^|[_-])(orm|rma|arm)(?:[_-]|$)/.test(stem);
+  // "arm" (AO/Roughness/Metallic) is a real packing convention, but it is also
+  // a body part, and a false positive here rebinds a metal-only map as if it
+  // were packed — the exact mirror bug this module exists to prevent. A false
+  // negative only costs some roughness detail, so the ambiguous token is out.
+  return /(?:^|[_-])(orm|rma)(?:[_-]|$)/.test(stem);
 }
 
 /**

--- a/lib/orm.js
+++ b/lib/orm.js
@@ -62,30 +62,59 @@ export function isPackedOrmName(filename) {
  */
 export function planOrm(spec, resolve, classify) {
   const res = typeof resolve === "function" ? resolve : () => null;
-  let metalName = spec && spec.metalnessUid ? res(spec.metalnessUid) : null;
-  const roughName = spec && spec.roughnessUid ? res(spec.roughnessUid) : null;
+  const s = spec || {};
+  let metalName = s.metalnessUid ? res(s.metalnessUid) : null;
+  const roughName = s.roughnessUid ? res(s.roughnessUid) : null;
 
   // Sketchfab sometimes points MetalnessPBR at a colour/id map, not a mask.
   if (metalName && typeof classify === "function" && classify(metalName) === "albedo") {
     metalName = null;
   }
 
-  if (metalName && !roughName && isPackedOrmName(metalName)) {
-    return { action: "passthrough", texture: metalName, reason: "already-packed ORM" };
+  if (!metalName && !roughName) {
+    return { action: "factors", reason: "no metal/rough maps" };
   }
 
-  if (metalName || roughName) {
-    return {
-      action: "pack",
-      metalName: metalName || null,
-      roughName: roughName || null,
-      // roughnessUid falls back to GlossinessPBR, which is inverted roughness.
-      invertRough: !!(spec && spec.roughnessIsGloss && roughName),
-      reason: metalName && roughName ? "separate metal + rough" : metalName ? "metal only" : "rough only",
-    };
+  // roughnessUid falls back to GlossinessPBR, which is inverted roughness.
+  const invertRough = !!(s.roughnessIsGloss && roughName);
+  const pack = (reason) => ({
+    action: "pack",
+    metalName: metalName || null,
+    roughName: roughName || null,
+    invertRough,
+    reason,
+  });
+
+  // 1. One texture wired to both channels is a packed map by construction.
+  const sameUid =
+    s.metalnessUid &&
+    s.roughnessUid &&
+    String(s.metalnessUid).toLowerCase() === String(s.roughnessUid).toLowerCase();
+  if (sameUid && metalName) {
+    return { action: "passthrough", texture: metalName, reason: "one texture on both channels" };
   }
 
-  return { action: "factors", reason: "no metal/rough maps" };
+  // 2. Two distinct maps always need packing.
+  if (metalName && roughName) return pack("separate metal + rough");
+
+  if (roughName) return pack("rough only");
+
+  // Metal map with no roughness map: the only genuinely ambiguous case.
+  // Prefer the format Sketchfab reports over anything in the filename.
+  const fmt = String(s.metalnessFormat || "").toUpperCase();
+  if (fmt === "LUMINANCE" || fmt === "ALPHA" || fmt === "LUMINANCE_ALPHA") {
+    return pack("single-channel metal map (LUMINANCE)");
+  }
+  if (fmt === "RGB" || fmt === "RGBA") {
+    return { action: "passthrough", texture: metalName, reason: `packed metal texture (${fmt})` };
+  }
+
+  // No format reported: fall back to the filename, then to packing, which is
+  // the safe direction — a wrong passthrough restores the mirror bug.
+  if (isPackedOrmName(metalName)) {
+    return { action: "passthrough", texture: metalName, reason: "name suggests packed ORM" };
+  }
+  return pack("metal only");
 }
 
 /**

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -790,22 +790,38 @@ function sampleLum(rgba, w, h, u, v) {
     return (rgba[o] * 77 + rgba[o + 1] * 150 + rgba[o + 2] * 29) >> 8;
 }
 
-async function bakeOpacityIntoAlbedo(albedoBytes, alphaBytes) {
+/**
+ * Multiply an opacity map into the albedo's alpha channel.
+ *
+ * Reports whether the result actually carries transparency: Sketchfab ships a
+ * flat white Opacity map for plenty of fully opaque materials, and exporting
+ * those as BLEND makes Blender/EEVEE drop depth writes, so a solid object
+ * renders see-through.
+ *
+ * @returns {Promise<{data: Uint8Array, hasTransparency: boolean}|null>}
+ */
+export async function bakeOpacityIntoAlbedo(albedoBytes, alphaBytes) {
     const a = await decodePngRgba(albedoBytes);
     const m = await decodePngRgba(alphaBytes);
     if (!a.width || !m.width) return null;
     const out = new Uint8ClampedArray(a.rgba);
     const same = a.width === m.width && a.height === m.height;
+    let hasTransparency = false;
     for (let y = 0; y < a.height; y++) {
         for (let x = 0; x < a.width; x++) {
             const o = (y * a.width + x) * 4;
             const lum = same
                 ? (m.rgba[o] * 77 + m.rgba[o + 1] * 150 + m.rgba[o + 2] * 29) >> 8
                 : sampleLum(m.rgba, m.width, m.height, x / (a.width - 1 || 1), y / (a.height - 1 || 1));
-            out[o + 3] = Math.round((out[o + 3] * lum) / 255);
+            const v = Math.round((out[o + 3] * lum) / 255);
+            out[o + 3] = v;
+            if (v < 250) hasTransparency = true;
         }
     }
-    return encodePngRgba(out, a.width, a.height);
+    return {
+        data: await encodePngRgba(out, a.width, a.height),
+        hasTransparency,
+    };
 }
 
 async function bakeTintWithAlpha(factor, alphaBytes) {
@@ -1200,7 +1216,10 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             }
             // Opacity / cutout from viewer material
             const opType = String(map.opacityType || '');
-            if (map.opacityEnable && /dither/i.test(opType)) {
+            if (map.forceOpaque) {
+                // Opacity map baked out to fully opaque — see bakeOpacityIntoAlbedo
+                material.alphaMode = 'OPAQUE';
+            } else if (map.opacityEnable && /dither/i.test(opType)) {
                 // Dithered hair cards: albedo (Hair_AO) and opacity (Hair_M) are
                 // different atlases / UV sets. Official export uses BLEND, no bake.
                 material.alphaMode = 'BLEND';
@@ -1717,7 +1736,10 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
     if (/dither/i.test(String(map.opacityType || ''))) continue;
     const bakeKey = map.albedo + '|' + map.alpha;
     if (bakedDone.has(bakeKey)) {
-      map.albedo = bakedDone.get(bakeKey);
+      const prev = bakedDone.get(bakeKey);
+      // null == the bake was fully opaque, so it was skipped
+      if (prev) map.albedo = prev;
+      else map.forceOpaque = true;
       continue;
     }
     const aHit = findTextureBytes(map.albedo, textureFiles);
@@ -1726,11 +1748,18 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
     try {
       const baked = await bakeOpacityIntoAlbedo(aHit.data, mHit.data);
       if (!baked) continue;
+      if (!baked.hasTransparency) {
+        // Flat/opaque opacity map: keep the original albedo and export OPAQUE,
+        // otherwise EEVEE renders a solid object see-through.
+        bakedDone.set(bakeKey, null);
+        map.forceOpaque = true;
+        continue;
+      }
       const bakedName =
         textureBasename(map.albedo).replace(/\.[^.]+$/, '') + '_alpha.png';
-      textureFiles[bakedName] = baked;
-      textureFiles['textures/' + bakedName] = baked;
-      list.push({ name: 'textures/' + bakedName, data: baked });
+      textureFiles[bakedName] = baked.data;
+      textureFiles['textures/' + bakedName] = baked.data;
+      list.push({ name: 'textures/' + bakedName, data: baked.data });
       bakedDone.set(bakeKey, bakedName);
       map.albedo = bakedName;
     } catch (_) {}

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1,4 +1,5 @@
 import { decodePngRgba, encodePngRgba } from './descramble.js';
+import { isPackedOrmName } from './orm.js';
 
 // --- Browser helpers (Uint8Array instead of Node Buffer) ---
 function concatBytes(chunks) {
@@ -531,6 +532,30 @@ export function classifyTextureName(filename) {
 }
 
 /**
+ * Resolve the PBR factors for a material, and whether its metal/rough texture
+ * may be bound to metallicRoughnessTexture.
+ *
+ * glTF reads that texture as packed: green = roughness, blue = metalness.
+ * Sketchfab's single-channel `*_metallic` map is therefore only safe to bind
+ * after it has been packed with the matching roughness map — otherwise its
+ * green channel drives roughness and non-metal surfaces render as mirrors.
+ * Without a packed map the numeric factors from the viewer are authoritative,
+ * including an explicit metallicFactor of 0.
+ *
+ * @param {object|null} map
+ * @returns {{metallicFactor: number, roughnessFactor: number, bindTexture: boolean}}
+ */
+export function pbrFactors(map) {
+    const metalF = map && typeof map.metallicFactor === 'number' ? map.metallicFactor : 0;
+    const roughF = map && typeof map.roughnessFactor === 'number' ? map.roughnessFactor : 0.9;
+    if (map && map.metalness && map.ormPacked) {
+        // Factors multiply the texture, so 1.0 lets the map drive both channels.
+        return { metallicFactor: 1, roughnessFactor: 1, bindTexture: true };
+    }
+    return { metallicFactor: metalF, roughnessFactor: roughF, bindTexture: false };
+}
+
+/**
  * Normalize material / texture identity for fuzzy matching.
  * Do NOT strip multi-digit suffixes like Equip_02 — only a single trailing
  * instance index (_0 … _9) used on mesh names.
@@ -884,10 +909,21 @@ function buildTextureMaps(geometries, textureList, textureFiles, viewerMaterials
             // Dropping it must also drop factor=1, or hair cards go chrome.
             if (metalTex && classifyTextureName(metalTex) === 'albedo') metalTex = null;
             if (spec.metalnessUid && !metalTex) metallicFactor = 0;
+            // Sketchfab serves metalness and roughness separately; the pipeline
+            // packs them into one ORM map. Only a genuinely packed texture may
+            // drive metallicRoughnessTexture (see pbrFactors).
+            let ormPacked = false;
+            if (spec.packedOrmName) {
+                metalTex = spec.packedOrmName;
+                ormPacked = true;
+            } else if (metalTex && isPackedOrmName(metalTex)) {
+                ormPacked = true;
+            }
             const map = {
                 albedo,
                 normal: resolveUidToBase(spec.normalUid, list),
                 metalness: metalTex,
+                ormPacked,
                 emissive: resolveUidToBase(spec.emitUid, list),
                 occlusion: resolveUidToBase(spec.aoUid, list),
                 alpha,
@@ -1115,18 +1151,15 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
      * Defaults match Sketchfab lit/PBR: metalness 0, no invented ORM maps.
      */
     function makeMaterial(name, map) {
-        const metalF = map && typeof map.metallicFactor === 'number' ? map.metallicFactor : 0;
-        const roughF = map && typeof map.roughnessFactor === 'number' ? map.roughnessFactor : 0.9;
         const baseF = (map && map.baseColorFactor) || [1, 1, 1, 1];
-        const hasMetalMap = !!(map && map.metalness);
+        const factors = pbrFactors(map);
         const material = {
             name: name || 'Material',
             doubleSided: true,
             pbrMetallicRoughness: {
                 baseColorFactor: baseF.slice(0, 4),
-                // If a metal/rough texture is present, factors multiply the texture
-                metallicFactor: hasMetalMap ? (metalF > 0 ? metalF : 1.0) : metalF,
-                roughnessFactor: hasMetalMap ? 1.0 : roughF,
+                metallicFactor: factors.metallicFactor,
+                roughnessFactor: factors.roughnessFactor,
             }
         };
         if (map && map.via) {
@@ -1140,7 +1173,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                     material.pbrMetallicRoughness.baseColorTexture = { index: idx, texCoord: 0 };
                 }
             }
-            if (map.metalness) {
+            if (map.metalness && factors.bindTexture) {
                 const idx = addTexture(map.metalness);
                 if (idx >= 0) {
                     material.pbrMetallicRoughness.metallicRoughnessTexture = {
@@ -1199,6 +1232,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 'a:' + (map.albedo || ''),
                 'n:' + (map.normal || ''),
                 'm:' + (map.metalness || ''),
+                'op:' + (map.ormPacked ? 1 : 0),
                 'e:' + (map.emissive || ''),
                 'o:' + (map.occlusion || ''),
                 'mf:' + (map.metallicFactor != null ? map.metallicFactor : ''),

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -477,7 +477,7 @@ function processGeometry(geom, polyBin, wireBin, sharedState) {
 // --- Texture helpers ---
 
 /** Basename of a texture path, strip optional "32hexuid_" prefix from download naming. */
-function textureBasename(filename) {
+export function textureBasename(filename) {
     let base = String(filename || '').split('/').pop();
     base = base.replace(/^[a-f0-9]{32}_/i, '');
     return base;
@@ -693,7 +693,7 @@ function mapTexturesForName(matName, geomName, textureList) {
 /**
  * Resolve a texture set/image uid to a downloaded texture basename.
  */
-function resolveUidToBase(uid, textureList) {
+export function resolveUidToBase(uid, textureList) {
     if (!uid) return null;
     const u = String(uid).toLowerCase();
     for (const t of textureList || []) {

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -956,6 +956,7 @@ function buildTextureMaps(geometries, textureList, textureFiles, viewerMaterials
                 opacityEnable: !!spec.opacityEnable,
                 opacityFactor: spec.opacityFactor,
                 opacityType: spec.opacityType,
+                transmission: !!spec.transmission,
                 opacityAsAlbedo: usedOpacityAsAlbedo,
                 via: found.via,
             };
@@ -1041,6 +1042,8 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         images: [],
         samplers: []
     };
+    // Extensions are only declared when a material actually emits one.
+    const usedExtensions = new Set();
 
     const binChunks = [];
     let byteOffset = 0;
@@ -1216,7 +1219,16 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             }
             // Opacity / cutout from viewer material
             const opType = String(map.opacityType || '');
-            if (map.forceOpaque) {
+            if (map.transmission) {
+                // Sketchfab "refraction" glass. KHR_materials_transmission keeps
+                // it see-through while the roughness map still drives the
+                // reflection, which BLEND cannot do. Spec says stay OPAQUE.
+                material.extensions = material.extensions || {};
+                material.extensions.KHR_materials_transmission = { transmissionFactor: 1 };
+                material.alphaMode = 'OPAQUE';
+                material.doubleSided = false;
+                usedExtensions.add('KHR_materials_transmission');
+            } else if (map.forceOpaque) {
                 // Opacity map baked out to fully opaque — see bakeOpacityIntoAlbedo
                 material.alphaMode = 'OPAQUE';
             } else if (map.opacityEnable && /dither/i.test(opType)) {
@@ -1370,6 +1382,10 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
 
     const binBuffer = concatBytes(binChunks);
     gltf.buffers.push({ byteLength: binBuffer.length });
+
+    if (usedExtensions.size) {
+        gltf.extensionsUsed = [...usedExtensions];
+    }
 
     return { json: gltf, bin: binBuffer };
 }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -16,8 +16,99 @@ import {
 } from "./sf-api.js";
 import { decryptBinzBytes, loadWasmBytes, outNameFor } from "./decrypt.js";
 import { buildZip } from "./zip.js";
-import { convertOsgjsToGlbFromFiles } from "./osgjs2gltf.js";
+import { convertOsgjsToGlbFromFiles, classifyTextureName } from "./osgjs2gltf.js";
+import { planOrm, packOrmTexture } from "./orm.js";
 import { GITHUB_URL, isDownloadTextures, loadPrefs } from "./settings.js";
+
+/**
+ * Pack each material's separate metalness / roughness maps into one glTF ORM
+ * texture, appending the result to the texture list and tagging the spec so
+ * the converter binds it.
+ *
+ * Failures are non-fatal: the material falls back to numeric factors, which
+ * looks flat but never turns a plastic surface into a mirror.
+ *
+ * @param {Map<string, object>} viewerMaterials
+ * @param {Array<{name: string, data: Uint8Array, uid?: string}>} textures
+ * @param {(msg: string) => void} step
+ * @param {number} maxTextureEdge
+ * @returns {Promise<Array>} textures, plus any packed ORM maps
+ */
+async function packOrmMaps(viewerMaterials, textures, step, maxTextureEdge) {
+  if (!viewerMaterials || !viewerMaterials.size || !textures.length) return textures;
+
+  const byBase = new Map();
+  for (const t of textures) {
+    byBase.set(String(t.name).split("/").pop().toLowerCase(), t);
+  }
+  const resolve = (uid) => {
+    if (!uid) return null;
+    const u = String(uid).toLowerCase();
+    for (const t of textures) {
+      if (t.uid && String(t.uid).toLowerCase() === u) return String(t.name).split("/").pop();
+      if (t.imageUids && t.imageUids.some((id) => String(id).toLowerCase() === u)) {
+        return String(t.name).split("/").pop();
+      }
+    }
+    return null;
+  };
+  const entryFor = (base) => (base ? byBase.get(base.toLowerCase()) || null : null);
+
+  const added = [];
+  let packed = 0;
+  let reused = 0;
+  const cache = new Map();
+
+  for (const spec of viewerMaterials.values()) {
+    const plan = planOrm(spec, resolve, classifyTextureName);
+    if (plan.action !== "pack") continue;
+
+    const key = `${plan.metalName || "-"}|${plan.roughName || "-"}|${plan.invertRough ? 1 : 0}`;
+    if (cache.has(key)) {
+      spec.packedOrmName = cache.get(key);
+      reused++;
+      continue;
+    }
+
+    const metal = entryFor(plan.metalName);
+    const rough = entryFor(plan.roughName);
+    if (!metal && !rough) continue;
+
+    const stem = String(plan.metalName || plan.roughName)
+      .replace(/\.[^.]+$/, "")
+      .replace(/_(metallic|metalness|metal|roughness|rough|gloss|glossiness)$/i, "");
+    const outName = `textures/${stem}_ORM.png`;
+
+    try {
+      const result = await packOrmTexture({
+        metal,
+        rough,
+        invertRough: plan.invertRough,
+        maxEdge: maxTextureEdge,
+      });
+      added.push({
+        name: outName,
+        data: result.data,
+        uid: "",
+        originalName: `${stem}_ORM.png`,
+        width: result.width,
+        height: result.height,
+        fromOrmPack: true,
+      });
+      byBase.set(`${stem}_ORM.png`.toLowerCase(), added[added.length - 1]);
+      cache.set(key, `${stem}_ORM.png`);
+      spec.packedOrmName = `${stem}_ORM.png`;
+      packed++;
+    } catch (e) {
+      step(`  ORM pack failed for ${spec.name || "?"}: ${e && e.message ? e.message : e}`);
+    }
+  }
+
+  if (packed || reused) {
+    step(`  Packed ${packed} ORM map(s) from separate metal/rough maps` + (reused ? ` (${reused} shared)` : ""));
+  }
+  return added.length ? textures.concat(added) : textures;
+}
 
 const README_TXT = [
   "Sketchfab Public Downloader v1.0",
@@ -179,6 +270,9 @@ export async function downloadModel(pageUrl, onProgress = () => {}, options = {}
           "  (No viewer-blit captures — reload the model page AFTER enabling the extension, wait for full load)"
         );
       }
+    }
+    if (textures.length) {
+      textures = await packOrmMaps(viewerMaterials, textures, step, maxTextureEdge);
     }
     for (const t of textures) decrypted[t.name] = t.data;
     if (textures.length) {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -16,7 +16,12 @@ import {
 } from "./sf-api.js";
 import { decryptBinzBytes, loadWasmBytes, outNameFor } from "./decrypt.js";
 import { buildZip } from "./zip.js";
-import { convertOsgjsToGlbFromFiles, classifyTextureName } from "./osgjs2gltf.js";
+import {
+  convertOsgjsToGlbFromFiles,
+  classifyTextureName,
+  resolveUidToBase,
+  textureBasename,
+} from "./osgjs2gltf.js";
 import { planOrm, packOrmTexture } from "./orm.js";
 import { GITHUB_URL, isDownloadTextures, loadPrefs } from "./settings.js";
 
@@ -37,22 +42,15 @@ import { GITHUB_URL, isDownloadTextures, loadPrefs } from "./settings.js";
 async function packOrmMaps(viewerMaterials, textures, step, maxTextureEdge) {
   if (!viewerMaterials || !viewerMaterials.size || !textures.length) return textures;
 
+  // Resolve uids exactly the way the converter does, so a texture the
+  // converter would bind is never one the packer failed to find.
   const byBase = new Map();
   for (const t of textures) {
-    byBase.set(String(t.name).split("/").pop().toLowerCase(), t);
+    byBase.set(textureBasename(t.name).toLowerCase(), t);
   }
-  const resolve = (uid) => {
-    if (!uid) return null;
-    const u = String(uid).toLowerCase();
-    for (const t of textures) {
-      if (t.uid && String(t.uid).toLowerCase() === u) return String(t.name).split("/").pop();
-      if (t.imageUids && t.imageUids.some((id) => String(id).toLowerCase() === u)) {
-        return String(t.name).split("/").pop();
-      }
-    }
-    return null;
-  };
-  const entryFor = (base) => (base ? byBase.get(base.toLowerCase()) || null : null);
+  const resolve = (uid) => resolveUidToBase(uid, textures);
+  const entryFor = (base) =>
+    base ? byBase.get(textureBasename(base).toLowerCase()) || null : null;
 
   const added = [];
   let packed = 0;

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -85,6 +85,16 @@ export function parseViewerMaterials(info) {
       if (!t || !t.uid) return null;
       return String(t.uid).toLowerCase();
     };
+    /**
+     * Sketchfab reports the texture's internal format. LUMINANCE is a
+     * single-channel map, so it can never already be a packed ORM; RGB/RGBA on
+     * a metalness channel is what a packed one actually looks like.
+     */
+    const getTexFormat = (channel) => {
+      const c = ch[channel];
+      const t = c && c.texture;
+      return t && t.internalFormat ? String(t.internalFormat).toUpperCase() : "";
+    };
     const getFactor = (channel, def) => {
       const c = ch[channel];
       if (!c || c.enable === false) return def;
@@ -156,6 +166,7 @@ export function parseViewerMaterials(info) {
       // GlossinessPBR is inverted roughness. The factor is converted above;
       // consumers of the *texture* must invert it too (see packOrmPixels).
       roughnessIsGloss: !roughness && !!gloss,
+      metalnessFormat: getTexFormat("MetalnessPBR"),
       specularUid: specular,
       aoUid: ao,
       opacityUid: opacityTex,

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -125,13 +125,25 @@ export function parseViewerMaterials(info) {
     const opacityType = opacity.type || alphaMask.type || "";
     const albedoFactor = getFactor("AlbedoPBR", 1);
 
-    // Glass / invisible shells create a "veil" if exported opaque
-    const skipMesh =
+    // Sketchfab's refraction opacity is real glass, not an invisible shell.
+    // glTF expresses it with KHR_materials_transmission, so it can be exported
+    // instead of dropped.
+    const transmission = opacityEnable && /refract/i.test(opacityType);
+
+    // Genuinely invisible: nothing to export at any opacity model.
+    const invisible =
       opacityEnable &&
       (opacityFactor <= 0.01 ||
-        /glass/i.test(name) ||
-        /rim/i.test(name) ||
         (opacityType === "additive" && albedoFactor <= 0.01));
+
+    // Glass / invisible shells create a "veil" if exported opaque. Name matching
+    // is a blunt instrument though — a visible refractive cover (opacity factor
+    // 1) hit this too and lost the model its glass. Only drop a named shell when
+    // it cannot be represented faithfully.
+    const namedVeil =
+      opacityEnable && (/glass/i.test(name) || /rim/i.test(name));
+
+    const skipMesh = invisible || (namedVeil && !transmission);
 
     const normalCh = ch.NormalMap || {};
     out.set(name, {
@@ -155,6 +167,7 @@ export function parseViewerMaterials(info) {
       opacityEnable,
       opacityFactor,
       opacityType,
+      transmission,
       albedoFactor,
       skipMesh,
       // solid tint when no albedo texture

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -141,6 +141,9 @@ export function parseViewerMaterials(info) {
       normalUid: normal,
       metalnessUid: metalness,
       roughnessUid: roughness || gloss,
+      // GlossinessPBR is inverted roughness. The factor is converted above;
+      // consumers of the *texture* must invert it too (see packOrmPixels).
+      roughnessIsGloss: !roughness && !!gloss,
       specularUid: specular,
       aoUid: ao,
       opacityUid: opacityTex,

--- a/test/materials.test.js
+++ b/test/materials.test.js
@@ -92,3 +92,60 @@ test("shouldSkipUntexturedShell keeps hair that has an opacity atlas", () => {
     true
   );
 });
+
+test("a visible refractive glass cover is exported, not skipped", () => {
+  // vpcm2_glass_cover: opacity factor 1, type 'refraction'. The old name-based
+  // /glass/i rule dropped the mesh, so the model lost its glossy screen.
+  const info = {
+    options: {
+      materials: {
+        g1: {
+          name: "vpcm2_glass_cover",
+          channels: {
+            AlbedoPBR: tex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true),
+            Opacity: { enable: true, factor: 1, type: "refraction" },
+          },
+        },
+      },
+    },
+  };
+  const spec = parseViewerMaterials(info).get("vpcm2_glass_cover");
+  assert.equal(spec.skipMesh, false, "visible glass must survive export");
+  assert.equal(spec.transmission, true, "and be marked for KHR_materials_transmission");
+});
+
+test("an invisible glass shell is still skipped", () => {
+  const info = {
+    options: {
+      materials: {
+        g1: {
+          name: "window_glass",
+          channels: {
+            AlbedoPBR: tex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true),
+            Opacity: { enable: true, factor: 0, type: "alphaBlend" },
+          },
+        },
+      },
+    },
+  };
+  const spec = parseViewerMaterials(info).get("window_glass");
+  assert.equal(spec.skipMesh, true, "a fully transparent veil must still be dropped");
+});
+
+test("a non-refractive named glass shell is still skipped", () => {
+  const info = {
+    options: {
+      materials: {
+        g1: {
+          name: "glass_rim",
+          channels: {
+            AlbedoPBR: tex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true),
+            Opacity: { enable: true, factor: 1, type: "alphaBlend" },
+          },
+        },
+      },
+    },
+  };
+  const spec = parseViewerMaterials(info).get("glass_rim");
+  assert.equal(spec.skipMesh, true);
+});

--- a/test/orm.test.js
+++ b/test/orm.test.js
@@ -149,3 +149,19 @@ test("a flat white opacity map bakes to fully opaque, so BLEND is not warranted"
   const holed = await bakeOpacityIntoAlbedo(albedoPng, await encodePngRgba(holeMask, size, size));
   assert.equal(holed.hasTransparency, true, "a real cutout must still request BLEND");
 });
+
+test("the packer resolves uids through the converter's own resolver", async () => {
+  // The pipeline used to carry a second, subtly different copy of this logic:
+  // it missed Sketchfab's 32-hex filename prefix and the substring fallback, so
+  // it could decline to pack a texture the converter went on to bind.
+  const { resolveUidToBase, textureBasename } = await import("../lib/osgjs2gltf.js");
+  assert.equal(typeof resolveUidToBase, "function", "pipeline imports this at runtime");
+  assert.equal(typeof textureBasename, "function", "pipeline imports this at runtime");
+
+  const list = [
+    { name: "textures/aabbccddeeff00112233445566778899_case_metallic.jpg", uid: "M1", imageUids: [] },
+    { name: "textures/case_roughness.jpg", uid: "R1", imageUids: ["R2"] },
+  ];
+  assert.equal(resolveUidToBase("M1", list), "case_metallic.jpg", "strips the uid prefix");
+  assert.equal(resolveUidToBase("R2", list), "case_roughness.jpg", "matches via imageUids");
+});

--- a/test/orm.test.js
+++ b/test/orm.test.js
@@ -18,6 +18,10 @@ test("isPackedOrmName separates packed ORM from single-channel maps", () => {
   // the case that shipped the bug: classifies as 'metalrough' but is metal-only
   assert.equal(isPackedOrmName("vpcm2_case_metallic.jpg"), false);
   assert.equal(isPackedOrmName("vpcm2_case_roughness.jpg"), false);
+  // "arm" is a body part far more often than an AO/Roughness/Metallic pack;
+  // treating one as packed would rebind a metal-only map and restore the bug.
+  assert.equal(isPackedOrmName("Character_arm_metallic.png"), false);
+  assert.equal(isPackedOrmName("robot_arm_roughness.jpg"), false);
   assert.equal(classifyTextureName("vpcm2_case_metallic.jpg"), "metalrough");
 });
 

--- a/test/orm.test.js
+++ b/test/orm.test.js
@@ -1,0 +1,124 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isPackedOrmName, planOrm, packOrmPixels } from "../lib/orm.js";
+import { classifyTextureName, pbrFactors } from "../lib/osgjs2gltf.js";
+
+/** uid -> basename resolver over a fake downloaded texture list */
+function resolverFor(map) {
+  return (uid) => map[uid] || null;
+}
+
+const M_UID = "11111111111111111111111111111111";
+const R_UID = "22222222222222222222222222222222";
+
+test("isPackedOrmName separates packed ORM from single-channel maps", () => {
+  assert.equal(isPackedOrmName("vpcm2_case_ORM.png"), true);
+  assert.equal(isPackedOrmName("Body_mrao.jpg"), true);
+  assert.equal(isPackedOrmName("Body_MetallicRoughness.png"), true);
+  // the case that shipped the bug: classifies as 'metalrough' but is metal-only
+  assert.equal(isPackedOrmName("vpcm2_case_metallic.jpg"), false);
+  assert.equal(isPackedOrmName("vpcm2_case_roughness.jpg"), false);
+  assert.equal(classifyTextureName("vpcm2_case_metallic.jpg"), "metalrough");
+});
+
+test("planOrm packs when metalness and roughness are separate maps", () => {
+  const spec = { metalnessUid: M_UID, roughnessUid: R_UID };
+  const plan = planOrm(
+    spec,
+    resolverFor({ [M_UID]: "vpcm2_case_metallic.jpg", [R_UID]: "vpcm2_case_roughness.jpg" }),
+    classifyTextureName
+  );
+  assert.equal(plan.action, "pack");
+  assert.equal(plan.metalName, "vpcm2_case_metallic.jpg");
+  assert.equal(plan.roughName, "vpcm2_case_roughness.jpg");
+  assert.equal(plan.invertRough, false);
+});
+
+test("planOrm passes an already-packed ORM through untouched", () => {
+  const spec = { metalnessUid: M_UID };
+  const plan = planOrm(spec, resolverFor({ [M_UID]: "Body_ORM.png" }), classifyTextureName);
+  assert.equal(plan.action, "passthrough");
+  assert.equal(plan.texture, "Body_ORM.png");
+});
+
+test("planOrm still packs a metal-only map instead of binding it raw", () => {
+  const spec = { metalnessUid: M_UID };
+  const plan = planOrm(spec, resolverFor({ [M_UID]: "case_metallic.jpg" }), classifyTextureName);
+  assert.equal(plan.action, "pack");
+  assert.equal(plan.roughName, null);
+});
+
+test("planOrm drops MetalnessPBR pointed at a colour map", () => {
+  const spec = { metalnessUid: M_UID };
+  const plan = planOrm(spec, resolverFor({ [M_UID]: "Body_D.png" }), classifyTextureName);
+  assert.equal(plan.action, "factors");
+});
+
+test("planOrm flags glossiness so it can be inverted", () => {
+  const spec = { metalnessUid: M_UID, roughnessUid: R_UID, roughnessIsGloss: true };
+  const plan = planOrm(
+    spec,
+    resolverFor({ [M_UID]: "m_metallic.jpg", [R_UID]: "m_gloss.jpg" }),
+    classifyTextureName
+  );
+  assert.equal(plan.action, "pack");
+  assert.equal(plan.invertRough, true);
+});
+
+test("packOrmPixels writes roughness to green and metalness to blue", () => {
+  const px = (v) => Uint8Array.from([v, v, v, 255]);
+  const out = packOrmPixels({ metal: px(20), rough: px(200), width: 1, height: 1 });
+  assert.equal(out[0], 255, "red free for occlusion");
+  assert.equal(out[1], 200, "green = roughness");
+  assert.equal(out[2], 20, "blue = metalness");
+  assert.equal(out[3], 255);
+});
+
+test("packOrmPixels inverts glossiness into roughness", () => {
+  const out = packOrmPixels({
+    metal: Uint8Array.from([0, 0, 0, 255]),
+    rough: Uint8Array.from([230, 230, 230, 255]),
+    width: 1,
+    height: 1,
+    invertRough: true,
+  });
+  assert.equal(out[1], 25, "gloss 230 -> roughness 25");
+});
+
+test("packOrmPixels defaults a missing roughness map to rough, not mirror", () => {
+  const out = packOrmPixels({
+    metal: Uint8Array.from([0, 0, 0, 255]),
+    rough: null,
+    width: 1,
+    height: 1,
+  });
+  assert.ok(out[1] > 200, `expected a rough default, got ${out[1]}`);
+  assert.equal(out[2], 0);
+});
+
+test("pbrFactors keeps viewer roughness when no packed ORM is bound", () => {
+  // The shipped bug: a metal-only texture forced both factors to 1, so a black
+  // metal map drove roughness to 0 and every material became a mirror.
+  const f = pbrFactors({ metalness: "case_metallic.jpg", metallicFactor: 0, roughnessFactor: 0.9 });
+  assert.equal(f.bindTexture, false, "must not bind a non-packed map");
+  assert.equal(f.metallicFactor, 0);
+  assert.equal(f.roughnessFactor, 0.9);
+});
+
+test("pbrFactors lets a packed ORM drive both channels", () => {
+  const f = pbrFactors({
+    metalness: "case_ORM.png",
+    ormPacked: true,
+    metallicFactor: 0,
+    roughnessFactor: 0.9,
+  });
+  assert.equal(f.bindTexture, true);
+  assert.equal(f.metallicFactor, 1);
+  assert.equal(f.roughnessFactor, 1);
+});
+
+test("pbrFactors does not promote an explicit metallicFactor of 0", () => {
+  const f = pbrFactors({ metallicFactor: 0, roughnessFactor: 0.4 });
+  assert.equal(f.metallicFactor, 0);
+  assert.equal(f.roughnessFactor, 0.4);
+});

--- a/test/orm.test.js
+++ b/test/orm.test.js
@@ -122,3 +122,26 @@ test("pbrFactors does not promote an explicit metallicFactor of 0", () => {
   assert.equal(f.metallicFactor, 0);
   assert.equal(f.roughnessFactor, 0.4);
 });
+
+test("a flat white opacity map bakes to fully opaque, so BLEND is not warranted", async () => {
+  const { encodePngRgba } = await import("../lib/descramble.js");
+  const { bakeOpacityIntoAlbedo } = await import("../lib/osgjs2gltf.js");
+
+  const size = 4;
+  const n = size * size;
+  const albedo = new Uint8ClampedArray(n * 4);
+  const opaqueMask = new Uint8ClampedArray(n * 4);
+  const holeMask = new Uint8ClampedArray(n * 4);
+  for (let i = 0; i < n; i++) {
+    albedo.set([120, 120, 120, 255], i * 4);
+    opaqueMask.set([255, 255, 255, 255], i * 4); // flat white == fully opaque
+    holeMask.set([i === 0 ? 0 : 255, i === 0 ? 0 : 255, i === 0 ? 0 : 255, 255], i * 4);
+  }
+  const albedoPng = await encodePngRgba(albedo, size, size);
+
+  const flat = await bakeOpacityIntoAlbedo(albedoPng, await encodePngRgba(opaqueMask, size, size));
+  assert.equal(flat.hasTransparency, false, "flat white opacity must not request BLEND");
+
+  const holed = await bakeOpacityIntoAlbedo(albedoPng, await encodePngRgba(holeMask, size, size));
+  assert.equal(holed.hasTransparency, true, "a real cutout must still request BLEND");
+});

--- a/test/orm.test.js
+++ b/test/orm.test.js
@@ -165,3 +165,48 @@ test("the packer resolves uids through the converter's own resolver", async () =
   assert.equal(resolveUidToBase("M1", list), "case_metallic.jpg", "strips the uid prefix");
   assert.equal(resolveUidToBase("R2", list), "case_roughness.jpg", "matches via imageUids");
 });
+
+test("LUMINANCE metalness is packed, never passed through", () => {
+  // Sketchfab reports the texture format. A single-channel map cannot already
+  // be a packed ORM, so this outranks any filename guess.
+  const spec = { metalnessUid: M_UID, metalnessFormat: "LUMINANCE" };
+  const plan = planOrm(spec, resolverFor({ [M_UID]: "case_metallic.jpg" }), classifyTextureName);
+  assert.equal(plan.action, "pack");
+});
+
+test("texture format outranks an ambiguous filename", () => {
+  // "arm" used to read as a packed ORM. With a reported LUMINANCE format the
+  // name is never consulted, so the collision cannot resurface.
+  const spec = { metalnessUid: M_UID, metalnessFormat: "LUMINANCE" };
+  const plan = planOrm(
+    spec,
+    resolverFor({ [M_UID]: "Character_arm_ORM.png" }),
+    classifyTextureName
+  );
+  assert.equal(plan.action, "pack", "LUMINANCE wins over an ORM-looking name");
+});
+
+test("an RGB metalness texture is a real packed ORM", () => {
+  const spec = { metalnessUid: M_UID, metalnessFormat: "RGB" };
+  const plan = planOrm(spec, resolverFor({ [M_UID]: "weird_name.png" }), classifyTextureName);
+  assert.equal(plan.action, "passthrough");
+});
+
+test("one texture on both channels is packed by construction", () => {
+  const spec = { metalnessUid: M_UID, roughnessUid: M_UID, metalnessFormat: "RGB" };
+  const plan = planOrm(spec, resolverFor({ [M_UID]: "Body_shared.png" }), classifyTextureName);
+  assert.equal(plan.action, "passthrough");
+  assert.equal(plan.texture, "Body_shared.png");
+});
+
+test("with no reported format the filename still decides, defaulting to pack", () => {
+  const noFmt = { metalnessUid: M_UID };
+  assert.equal(
+    planOrm(noFmt, resolverFor({ [M_UID]: "Body_ORM.png" }), classifyTextureName).action,
+    "passthrough"
+  );
+  assert.equal(
+    planOrm(noFmt, resolverFor({ [M_UID]: "Body_metallic.png" }), classifyTextureName).action,
+    "pack"
+  );
+});


### PR DESCRIPTION
Three separate defects in glTF material export, found while importing a public model into Blender. Each is a standalone commit so they can be taken or dropped independently.

Test model: `Vintage PC Monitor 2` (`29487562a3414f26a1b9c540e91a9137`).

Independent of #2, but reproducing any of this requires that fix (or saving the
ZIP by hand), since the download currently never reaches disk.

---

## 1. Every textured material renders as a mirror

`osgjs2gltf.js` bound Sketchfab's **metalness** map straight into
`pbrMetallicRoughness.metallicRoughnessTexture`. glTF reads that slot as a
*packed* texture — green is roughness, blue is metalness — so the metal map's
green channel drove roughness. A black (non-metal) map therefore read as
roughness 0 and the surface came out mirror-smooth.

`roughnessUid` was parsed in `sf-api.js` but **never consumed anywhere in the
converter**, so the authored roughness map was downloaded, written into the ZIP,
and then ignored. On the test model `vpcm2_case_roughness.jpg` is 905 KB of real
detail; the 28 KB metallic map was driving roughness in its place.

`makeMaterial` compounded it:

```js
metallicFactor: hasMetalMap ? (metalF > 0 ? metalF : 1.0) : metalF,
roughnessFactor: hasMetalMap ? 1.0 : roughF,
```

`metalF > 0 ? metalF : 1.0` cannot distinguish "the viewer says metalness is 0"
from "no value", so an explicitly non-metallic material was promoted to fully
metallic.

**Fix.** `lib/orm.js` packs the two maps into one ORM texture. The channel math
is DOM-free and unit tested; decode/encode sits behind it in `packOrmTexture()`
using `createImageBitmap` + `OffscreenCanvas` in the offscreen document.
`pbrFactors()` is now the single place deciding the factors *and* whether the
texture may be bound at all — only a genuinely packed map binds, otherwise the
viewer's numeric factors are authoritative.

Verified against the source maps: the packed green channel has mean **107.7**,
identical to `vpcm2_case_roughness.jpg`, and blue is **1.6**, identical to
`vpcm2_case_metallic.jpg`.

### Deciding what is already packed

`classifyTextureName()` answers `'metalrough'` for both `case_ORM.png` and
`case_metallic.jpg`, so it cannot be used for this. Rather than add more
filename patterns, the decision now reads what the viewer reports:

```
LUMINANCE -> AOPBR, MetalnessPBR, Opacity, RoughnessPBR
RGB       -> AlbedoPBR, NormalMap, EmitColor, DiffusePBR, Matcap, ...
```

A `LUMINANCE` texture is single-channel and can never already be packed;
`RGB`/`RGBA` on a metalness channel is what a packed map actually looks like.
Precedence is:

1. same texture uid on both channels → packed by construction
2. reported `LUMINANCE` → pack; `RGB`/`RGBA` → pass through
3. two distinct maps → pack
4. no format reported → filename, defaulting to **pack**

The default deliberately favours packing: a wrong pass-through restores the
mirror bug, a wrong pack only costs some roughness detail.

### Glossiness

`roughnessUid` falls back to `GlossinessPBR`, which is inverted roughness. The
*factor* was already converted (`1 - glossF`) but the *texture* was not, and
nothing downstream knew which it had. Harmless while the texture was unused —
but this PR starts using it, so specs now carry `roughnessIsGloss` and packing
inverts the channel.

---

## 2. Opaque materials export as `BLEND` and render see-through

Sketchfab ships a flat white Opacity map for plenty of materials that are not
transparent. `bakeOpacityIntoAlbedo()` multiplied it into the albedo alpha,
producing an all-255 alpha channel, and the material still exported with
`alphaMode: BLEND`.

Blender/EEVEE drops depth writes for blended materials, so a solid object
renders see-through against its own back faces. On the test model the baked
alpha was **min 255, max 255** — completely opaque — while `BLEND` was emitted
on every material.

**Fix.** The bake now reports whether any pixel actually landed below 250. When
none did, the baked texture is discarded, the original albedo is kept and the
material exports `OPAQUE`. Genuine cutouts and blends are untouched.

---

## 3. Visible glass covers are deleted from the export

`parseViewerMaterials()` skipped any material whose name matched `/glass/i` or
`/rim/i` whenever Opacity was enabled, to stop invisible shells exporting as
opaque veils. That is a real problem, but name matching is too blunt. On the
test model:

```
vpcm2_glass_cover  Opacity: { type: 'refraction', enable: true, factor: 1 }
```

Opacity factor **1** — nothing invisible about it. The mesh was dropped purely
because of its name, and the model lost the glossy screen the Sketchfab viewer
shows.

**Fix.** Sketchfab's `refraction` opacity is real glass, which glTF expresses
with `KHR_materials_transmission`. Blender maps it to the Principled
Transmission Weight, so the roughness map still drives the reflection —
something `BLEND` cannot do here, since the material's own opacity factor is 1
and would export fully opaque anyway. The skip logic now separates the cases:

- **invisible** (opacity ≤ 0.01, or additive with no albedo) → skipped, unchanged
- **named glass/rim shells** → skipped only when not representable as refraction
- **refractive** → exported with the transmission extension, `doubleSided` off

`extensionsUsed` is declared only when a material actually emits an extension,
so models that never hit this path produce byte-identical output.

---

## The pattern

All three came down to the same thing: the viewer already knew the answer.
`type: 'refraction'` settled the glass, `internalFormat: LUMINANCE` settled the
packing, and the roughness uid was sitting in the spec unused. Wherever this
code guessed from a filename, the authoritative value was one field away in the
prefetched JSON. That seemed worth saying beyond the individual fixes.

---

## Testing

- `npm test` — **45 pass, 0 fail**. The 23 pre-existing tests are unchanged and
  green, including the hair-card, cloth-atlas and specular-promotion regressions.
- 22 new tests covering pack/pass-through precedence, the channel math, gloss
  inversion, the opacity threshold, and the skip rules (a genuinely invisible
  veil and a non-refractive named shell are both still dropped).
- End-to-end on the test model: four ORM maps produced and bound, glass cover
  present with transmission, all materials `OPAQUE`, and the model imports into
  Blender correctly with no manual node edits.

## Notes

- **Memory and ZIP cost not measured.** ORM packing adds a per-material decode
  of two full-resolution maps plus a lossless PNG encode. `maxTextureEdge` is
  honoured, but "Original" is the default and I have not profiled a large 4K
  model.
- **Tested against one model** — the one that surfaced all three bugs.

Happy to split this into three PRs, drop the glass commit, or take a different
approach on any of it.

---

## Commits

```
Pack metalness + roughness into one ORM map instead of binding metal alone
Export OPAQUE when the opacity map bakes out fully opaque
Export refractive glass via KHR_materials_transmission instead of dropping it
Do not treat "arm" as a packed ORM token
Use the converter's uid resolver in the ORM packer
Decide ORM packing from the viewer's texture format, not the filename
```
