### PR TITLE
Read the scene's up-axis and pick decodable texture variants

### DIFF
--- a/lib/osg-codec.js
+++ b/lib/osg-codec.js
@@ -1,0 +1,97 @@
+/**
+ * Low-level decoders for Sketchfab's osgjs binary payloads, ported from the
+ * viewer bundle.
+ *
+ * They live apart from the converter because more than one caller needs them,
+ * and because the spherical decoder in particular is easy to get subtly wrong.
+ */
+
+/** Varint stream → Int32Array/Uint32Array (zigzag-decoded when signed). */
+export function decodeVarint(bytes, count, typeName) {
+  const signed = typeName[0] !== "U";
+  const result = signed ? new Int32Array(count) : new Uint32Array(count);
+  let a = 0;
+  let o = 0;
+  while (a < count) {
+    let s = 0;
+    let l = 0;
+    do {
+      s |= (bytes[o] & 127) << l;
+      l += 7;
+    } while ((bytes[o++] & 128) !== 0);
+    result[a++] = s;
+  }
+  if (signed) {
+    for (let u = 0; u < count; u++) {
+      const c = result[u];
+      result[u] = (c >> 1) ^ -(c & 1); // zigzag decode
+    }
+  }
+  return result;
+}
+
+/** In-place zigzag delta decode from startIdx onwards. */
+export function deltaDecodeInPlace(arr, startIdx) {
+  const start = startIdx || 0;
+  let prev = arr[start];
+  for (let i = start + 1; i < arr.length; i++) {
+    const v = arr[i];
+    prev = arr[i] = prev + ((v >> 1) ^ -(v & 1));
+  }
+  return arr;
+}
+
+/** output[i][j] = bbl[j] + encoded[i][j] * h[j] */
+export function dequantize(encoded, output, bbl, h, itemSize) {
+  const count = encoded.length / itemSize;
+  for (let i = 0; i < count; i++) {
+    const base = i * itemSize;
+    for (let j = 0; j < itemSize; j++) {
+      output[base + j] = bbl[j] + encoded[base + j] * h[j];
+    }
+  }
+  return output;
+}
+
+/**
+ * Decode a direction on the unit sphere from two packed components.
+ *
+ * With itemSize 4 the fourth output is a tangent's handedness, which rides in
+ * bit 1024 of the first component.
+ */
+export function decodeSpherical(encoded, output, itemSize, epsilon, nphi, hasThirdComponent) {
+  epsilon = epsilon || 0.25;
+  nphi = nphi || 720;
+  const PI = 3.14159265359;
+  const cosEps = Math.cos(0.01745329251 * epsilon);
+  const dPhi = PI / (nphi - 1);
+  const dGamma = 1.57079632679 / (nphi - 1);
+  const stride = hasThirdComponent ? 3 : 2;
+  const count = encoded.length / stride;
+
+  for (let i = 0; i < count; i++) {
+    const outIdx = i * itemSize;
+    const inIdx = i * stride;
+    let S = encoded[inIdx];
+    const x = encoded[inIdx + 1];
+
+    if (itemSize === 4 && !hasThirdComponent) {
+      output[outIdx + 3] = S & 1024 ? -1 : 1;
+      S &= ~1024;
+    }
+
+    const A0 = S * dPhi;
+    const R = Math.cos(A0);
+    const w = Math.sin(A0);
+    const A1 = A0 + dGamma;
+    let E = (cosEps - R * Math.cos(A1)) / Math.max(1e-5, w * Math.sin(A1));
+    if (E > 1) E = 1;
+    else if (E < -1) E = -1;
+    const P = (6.28318530718 * x) / Math.ceil(PI / Math.max(1e-5, Math.acos(E)));
+
+    output[outIdx] = w * Math.cos(P);
+    output[outIdx + 1] = w * Math.sin(P);
+    output[outIdx + 2] = R;
+  }
+  return output;
+}

--- a/lib/osg-scene.js
+++ b/lib/osg-scene.js
@@ -1,0 +1,122 @@
+/**
+ * Scene-graph queries over a parsed osgjs document, plus the small matrix
+ * helpers they hand back.
+ *
+ * The converter flattens the node tree, so anything the graph says about
+ * orientation has to be read out before that happens.
+ */
+
+/** Column-major 3x3s; the source → glTF axis fix is always a pure rotation. */
+export const IDENTITY_MAT3 = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
+/** The viewer's world is Z-up, glTF is Y-up: (x, y, z) → (x, z, -y). */
+export const ZUP_TO_YUP_MAT3 = [1, 0, 0, 0, 0, -1, 0, 1, 0];
+
+/** Column-major 3x3 product a x b (b applied first). */
+export function mat3Multiply(a, b) {
+  const out = new Array(9);
+  for (let c = 0; c < 3; c++) {
+    for (let r = 0; r < 3; r++) {
+      let sum = 0;
+      for (let k = 0; k < 3; k++) sum += a[k * 3 + r] * b[c * 3 + k];
+      out[c * 3 + r] = sum;
+    }
+  }
+  return out;
+}
+
+/** Rotation/scale block of a column-major 4x4. */
+export function mat3FromMat4(m) {
+  return [m[0], m[1], m[2], m[4], m[5], m[6], m[8], m[9], m[10]];
+}
+
+/** Widen a 3x3 to a 4x4 with no translation. */
+export function mat4FromMat3(m) {
+  return [m[0], m[1], m[2], 0, m[3], m[4], m[5], 0, m[6], m[7], m[8], 0, 0, 0, 0, 1];
+}
+
+export function mat3Transpose(m) {
+  return [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]];
+}
+
+export function isIdentityMat3(m) {
+  for (let i = 0; i < 9; i++) {
+    if (Math.abs(m[i] - IDENTITY_MAT3[i]) > 1e-6) return false;
+  }
+  return true;
+}
+
+/** Outermost node carrying a transform, in scene order. */
+function outermostTransform(node, depth) {
+  if (!node || typeof node !== "object" || depth > 40) return null;
+  if (Array.isArray(node)) {
+    for (const v of node) {
+      const hit = outermostTransform(v, depth + 1);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  for (const value of Object.values(node)) {
+    if (
+      value &&
+      typeof value === "object" &&
+      Array.isArray(value.Matrix) &&
+      value.Matrix.length === 16
+    ) {
+      return value;
+    }
+    const hit = outermostTransform(value, depth + 1);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** True for a bare quarter turn about X: no translation, no scale, no tilt. */
+function isQuarterTurnAboutX(m) {
+  const eps = 1e-4;
+  const near = (a, b) => Math.abs(a - b) <= eps;
+  if (!near(m[12], 0) || !near(m[13], 0) || !near(m[14], 0)) return false;
+  if (!near(m[0], 1) || !near(m[1], 0) || !near(m[2], 0)) return false;
+  const s = m[6];
+  if (!near(Math.abs(s), 1)) return false;
+  return (
+    near(m[4], 0) && near(m[5], 0) && near(m[8], 0) && near(m[9], -s) && near(m[10], 0)
+  );
+}
+
+/**
+ * Sketchfab's coordinate-conversion wrapper, when the model has one.
+ *
+ * An upload that arrived as glTF is Y-up, and Sketchfab wraps it in a single
+ * transform that turns it into the viewer's Z-up world. Everything below stays
+ * Y-up — the baked vertex data included — so a converter that assumes Z-up
+ * source would turn such a model twice and lay it on its side.
+ *
+ * Only the outermost transform is considered, and only when it is a bare
+ * quarter turn about X. Object placement carries translation or scale, and
+ * mistaking that for a conversion would tilt the model rather than stand it
+ * up; a model without a wrapper keeps the Z-up assumption.
+ *
+ * @returns {object|null} the conversion node, whose Matrix maps content → world
+ */
+export function findAxisConversion(osgjs) {
+  const node = outermostTransform(osgjs, 0);
+  if (!node || !isQuarterTurnAboutX(node.Matrix)) return null;
+  return node;
+}
+
+/**
+ * Rotation to bake into vertex data so the export lands in glTF's Y-up frame.
+ *
+ * Z-up source content needs a quarter turn. A model that arrived as glTF is
+ * already Y-up below the conversion wrapper, though, and turning it again lays
+ * it on its side — composing with that wrapper cancels the two out, which is
+ * why the rotation is derived rather than assumed.
+ *
+ * @returns {{matrix: number[], node: object|null}}
+ */
+export function axisRotationFor(osgjs) {
+  const node = findAxisConversion(osgjs);
+  const conv = node ? mat3FromMat4(node.Matrix) : IDENTITY_MAT3;
+  return { matrix: mat3Multiply(ZUP_TO_YUP_MAT3, conv), node };
+}

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1,6 +1,12 @@
 import { decodePngRgba, encodePngRgba } from './descramble.js';
 import { isPackedOrmName } from './orm.js';
 import { axisRotationFor, isIdentityMat3 } from './osg-scene.js';
+import {
+    decodeVarint,
+    deltaDecodeInPlace,
+    dequantize,
+    decodeSpherical,
+} from './osg-codec.js';
 
 // --- Browser helpers (Uint8Array instead of Node Buffer) ---
 function concatBytes(chunks) {
@@ -48,81 +54,6 @@ function applyAxisRotation(result, m) {
 }
 
 // --- Sketchfab binary decoders (extracted from viewer JS) ---
-
-function decodeVarint(bytes, count, typeName) {
-    const signed = typeName[0] !== 'U';
-    const result = signed ? new Int32Array(count) : new Uint32Array(count);
-    let a = 0, o = 0;
-    while (a < count) {
-        let s = 0, l = 0;
-        do { s |= (bytes[o] & 127) << l; l += 7; } while ((bytes[o++] & 128) !== 0);
-        result[a++] = s;
-    }
-    if (signed) {
-        for (let u = 0; u < count; u++) {
-            const c = result[u];
-            result[u] = (c >> 1) ^ -(c & 1); // zigzag decode
-        }
-    }
-    return result;
-}
-
-function deltaDecodeInPlace(arr, startIdx) {
-    const start = startIdx || 0;
-    let prev = arr[start];
-    for (let i = start + 1; i < arr.length; i++) {
-        const v = arr[i];
-        prev = arr[i] = prev + (v >> 1 ^ -(v & 1));
-    }
-    return arr;
-}
-
-function dequantize(encoded, output, bbl, h, itemSize) {
-    const count = encoded.length / itemSize;
-    for (let i = 0; i < count; i++) {
-        const base = i * itemSize;
-        for (let j = 0; j < itemSize; j++) {
-            output[base + j] = bbl[j] + encoded[base + j] * h[j];
-        }
-    }
-    return output;
-}
-
-function decodeNormals(encoded, output, itemSize, epsilon, nphi, hasThirdComponent) {
-    epsilon = epsilon || 0.25;
-    nphi = nphi || 720;
-    const PI = 3.14159265359;
-    const cosEps = Math.cos(0.01745329251 * epsilon);
-    const dPhi = PI / (nphi - 1);
-    const dGamma = 1.57079632679 / (nphi - 1);
-    const stride = hasThirdComponent ? 3 : 2;
-    const count = encoded.length / stride;
-
-    for (let i = 0; i < count; i++) {
-        const outIdx = i * itemSize;
-        const inIdx = i * stride;
-        let S = encoded[inIdx];
-        let x = encoded[inIdx + 1];
-
-        if (itemSize === 4 && !hasThirdComponent) {
-            output[outIdx + 3] = (S & 1024) ? -1 : 1;
-            S &= ~1024;
-        }
-
-        const A0 = S * dPhi;
-        const R = Math.cos(A0);
-        const w = Math.sin(A0);
-        const A1 = A0 + dGamma;
-        let E = (cosEps - R * Math.cos(A1)) / Math.max(1e-5, w * Math.sin(A1));
-        if (E > 1) E = 1; else if (E < -1) E = -1;
-        const P = 6.28318530718 * x / Math.ceil(PI / Math.max(1e-5, Math.acos(E)));
-
-        output[outIdx] = w * Math.cos(P);
-        output[outIdx + 1] = w * Math.sin(P);
-        output[outIdx + 2] = R;
-    }
-    return output;
-}
 
 function implicitDecode(encoded, output, startIdx, useExpected) {
     let r = encoded[2]; // expectedIndex
@@ -377,7 +308,7 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation) {
         } else if (attrName === 'Normal') {
             if (attrFlags & 2) {
                 const floats = new Float32Array(count * 3);
-                decodeNormals(data, floats, 3, meta.epsilon, meta.nphi);
+                decodeSpherical(data, floats, 3, meta.epsilon, meta.nphi);
                 result.attributes.NORMAL = { data: floats, itemSize: 3, count };
             } else {
                 result.attributes.NORMAL = { data, itemSize, count };
@@ -385,7 +316,7 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation) {
         } else if (attrName === 'Tangent') {
             if (attrFlags & 32) {
                 const floats = new Float32Array(count * 4);
-                decodeNormals(data, floats, 4, meta.epsilon, meta.nphi);
+                decodeSpherical(data, floats, 4, meta.epsilon, meta.nphi);
                 result.attributes.TANGENT = { data: floats, itemSize: 4, count };
             }
         } else if (attrName.startsWith('TexCoord')) {

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1,5 +1,6 @@
 import { decodePngRgba, encodePngRgba } from './descramble.js';
 import { isPackedOrmName } from './orm.js';
+import { axisRotationFor, isIdentityMat3 } from './osg-scene.js';
 
 // --- Browser helpers (Uint8Array instead of Node Buffer) ---
 function concatBytes(chunks) {
@@ -25,6 +26,25 @@ function u32le(n) {
 }
 function typedToBytes(buf) {
   return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
+/** Rotate POSITION/NORMAL/TANGENT in place by a column-major 3x3. */
+function applyAxisRotation(result, m) {
+    if (!m || isIdentityMat3(m)) return;
+    for (const key of ['POSITION', 'NORMAL', 'TANGENT']) {
+        const attr = result.attributes[key];
+        if (!attr || !attr.data || (attr.itemSize || 0) < 3) continue;
+        const d = attr.data;
+        const stride = attr.itemSize;
+        for (let i = 0; i < d.length; i += stride) {
+            const x = d[i];
+            const y = d[i + 1];
+            const z = d[i + 2];
+            d[i] = m[0] * x + m[3] * y + m[6] * z;
+            d[i + 1] = m[1] * x + m[4] * y + m[7] * z;
+            d[i + 2] = m[2] * x + m[5] * y + m[8] * z;
+        }
+    }
 }
 
 // --- Sketchfab binary decoders (extracted from viewer JS) ---
@@ -240,7 +260,7 @@ function readBufferArray(binData, vb, typeName) {
     return new TypedArr(binData, offset, size * itemSize);
 }
 
-function processGeometry(geom, polyBin, wireBin, sharedState) {
+function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation) {
     const userData = sharedState || {};
     const result = { name: geom.Name || 'unnamed', attributes: {}, indices: null, mode: 'TRIANGLES', material: null };
     const meta = {};
@@ -455,21 +475,10 @@ function processGeometry(geom, polyBin, wireBin, sharedState) {
         if (m) result.materialName = m[0].replace(/_\d+$/, '');
     }
 
-    // OSG / viewer is Z-up. Official Sketchfab glTF bakes Y-up:
-    // (x, y, z) → (x, z, -y)  == rotate −90° about X.
-    // Doing it on the vertices (not a parent matrix) matches official mesh
-    // bounds and stands the model up in Blender without extra nodes.
-    for (const key of ['POSITION', 'NORMAL', 'TANGENT']) {
-        const attr = result.attributes[key];
-        if (!attr || !attr.data || (attr.itemSize || 0) < 3) continue;
-        const d = attr.data;
-        const s = attr.itemSize;
-        for (let i = 0; i < d.length; i += s) {
-            const y = d[i + 1];
-            d[i + 1] = d[i + 2];
-            d[i + 2] = -y;
-        }
-    }
+    // Baked into the vertices rather than carried on a parent matrix: it
+    // matches official Sketchfab mesh bounds, and the flattened node tree has
+    // nowhere to hang a transform.
+    applyAxisRotation(result, axisRotation);
 
     return result;
 }
@@ -1448,7 +1457,7 @@ function extractMeshGeometry(wrapper) {
     return null;
 }
 
-function collectGeometries(node, polyBin, wireBin) {
+function collectGeometries(node, polyBin, wireBin, axisRotation) {
     const uidMap = {};
     buildUidMap(node, uidMap);
     resolveRefs(node, uidMap);
@@ -1472,7 +1481,7 @@ function collectGeometries(node, polyBin, wireBin) {
         else seen.add(key);
 
         try {
-            const result = processGeometry(geom, polyBin, wireBin, sharedState);
+            const result = processGeometry(geom, polyBin, wireBin, sharedState, axisRotation);
             if (result.indices && result.attributes.POSITION) {
                 // Remap _TC_* to continuous TEXCOORD_0, TEXCOORD_1, ...
                 const tcKeys = Object.keys(result.attributes)
@@ -1659,7 +1668,9 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
       ? wireBin.buffer.slice(wireBin.byteOffset, wireBin.byteOffset + wireBin.byteLength)
       : wireBin);
 
-  const geometries = collectGeometries(osgjs, poly, wire);
+  // One axis decision for the whole model, read from the scene graph.
+  const axis = axisRotationFor(osgjs);
+  const geometries = collectGeometries(osgjs, poly, wire, axis.matrix);
   if (!geometries.length) {
     throw new Error(
       'No triangle geometries found in osgjs (checked osg.Geometry, RigGeometry.SourceGeometry, MorphGeometry)'

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -437,27 +437,42 @@ export async function fetchTextures(uid, onProgress, opts) {
     let scrambledHints = 0;
     let done = 0;
     const total = results.length;
-    const fetched = await mapPool(results, concurrency, async (tex, idx) => {
-      const i = idx + 1;
+    // Pick variants and file names before downloading: two textures can carry
+    // the same name, and resolving that inside the concurrent workers would
+    // make which one keeps the plain name depend on download order — while the
+    // loser silently overwrote the winner in the zip.
+    const usedNames = new Set();
+    const plan = results.map((tex, idx) => {
       const best = pickBestImage(tex.images || [], maxEdge, tex.pk);
       if (!best || !best.url) return null;
 
       const tuid = String(tex.uid || "").toLowerCase();
-      let base = String(tex.name || `texture_${i}`).replace(/[^\w.\-]+/g, "_");
+      let base = String(tex.name || `texture_${idx + 1}`).replace(/[^\w.\-]+/g, "_");
       const urlPath = best.url.split("?")[0];
       let ext = "";
       const mExt = base.match(/\.(png|jpe?g|webp|gif)$/i);
       if (mExt) {
         ext = mExt[0].toLowerCase().replace(".jpeg", ".jpg");
-        if (ext === ".jpeg") ext = ".jpg";
       } else {
         const uExt = (urlPath.match(/\.(png|jpe?g|webp|gif)$/i) || [])[0];
         if (uExt) ext = uExt.toLowerCase().replace(".jpeg", ".jpg");
         else ext = urlPath.includes(".png") ? ".png" : ".jpg";
         base = base + ext;
       }
+      if (usedNames.has(base.toLowerCase())) {
+        const stem = ext && base.toLowerCase().endsWith(ext)
+          ? base.slice(0, base.length - ext.length)
+          : base;
+        base = `${stem}_${tuid.slice(0, 8) || idx + 1}${ext}`;
+      }
+      usedNames.add(base.toLowerCase());
 
-      const pk = readPk(tex, best);
+      return { tex, best, base, tuid, pk: readPk(tex, best) };
+    });
+
+    const fetched = await mapPool(plan, concurrency, async (entry) => {
+      if (!entry) return null;
+      const { tex, best, base, tuid, pk } = entry;
       try {
         let bytes = await fetchBytes(best.url);
         if (!bytes || bytes.length < 32) return null;

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -284,20 +284,47 @@ export async function extractStaticKey(embedHtml, onProgress) {
  * Pick best image variant for a texture set.
  * Prefer max resolution; among same resolution prefer PNG (lossless) over JPEG.
  */
+/**
+ * Protection key for the chosen variant.
+ *
+ * Only the variant's own key counts — Sketchfab leaves `pk` null on the
+ * previews it serves unscrambled, and borrowing a sibling's key would
+ * "descramble" an image that was never scrambled.
+ */
 function readPk(tex, im) {
-  const vals = [];
-  if (im && im.pk != null) vals.push(im.pk);
-  if (tex && tex.pk != null) vals.push(tex.pk);
-  if (tex && tex.images) {
-    for (const x of tex.images) {
-      if (x && x.pk != null) vals.push(x.pk);
-    }
-  }
-  for (const v of vals) {
-    const n = typeof v === "number" ? v : Number(v);
-    if (Number.isFinite(n)) return n;
-  }
-  return null;
+  const own = im && Object.prototype.hasOwnProperty.call(im, "pk") ? im.pk : undefined;
+  const raw = own === undefined ? tex && tex.pk : own;
+  if (raw == null) return null;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function isPowerOfTwo(n) {
+  return n > 0 && (n & (n - 1)) === 0;
+}
+
+/**
+ * Whether a protected variant can actually be descrambled.
+ *
+ * The viewer only ever uploads power-of-two textures — WebGL1 needs them for
+ * mipmapping and REPEAT wrapping — so those are the only variants its
+ * protection shader is ever asked to reverse, and the only ones scrambled in a
+ * form that reverses. Sketchfab also keeps the raw upload at its original
+ * size; that copy is stored scrambled but nothing ever unscrambles it, and
+ * running the shader's permutation over it yields a patchwork.
+ *
+ * The permutation shuffles pixels within 8x8 tiles over a
+ * floor(w/8) x floor(h/8) grid while wrapping indices modulo w*h, so an
+ * off-grid size is not even a bijection: at 800x100 it reads 3040 pixels twice
+ * and never reads 6368 others. Power-of-two rules that out too.
+ */
+export function isDescramblable(im, texPk) {
+  if (!im) return false;
+  if (readPk({ pk: texPk }, im) == null) return true; // never scrambled
+  const w = im.width || 0;
+  const h = im.height || 0;
+  if (!w || !h) return true;
+  return isPowerOfTwo(w) && isPowerOfTwo(h);
 }
 
 function imageEdge(im) {
@@ -319,7 +346,7 @@ function scoreImage(im) {
  * maxEdge 0 / omitted = original (largest). Never downscale unless the
  * caller explicitly passes 2048 or 4096.
  */
-export function pickBestImage(images, maxEdge) {
+export function pickBestImage(images, maxEdge, texPk = null) {
   if (!images || !images.length) return null;
   const edge = maxEdge === 2048 || maxEdge === 4096 ? maxEdge : 0;
   const usable = [];
@@ -329,7 +356,9 @@ export function pickBestImage(images, maxEdge) {
     if (w > 0 && h > 0 && (w < 32 || h < 32)) continue;
     usable.push(im);
   }
-  const pool = usable.length ? usable : images.slice();
+  let pool = usable.length ? usable : images.slice();
+  const decodable = pool.filter((im) => isDescramblable(im, texPk));
+  if (decodable.length) pool = decodable;
   if (!edge) {
     let best = null;
     for (const im of pool) {
@@ -410,7 +439,7 @@ export async function fetchTextures(uid, onProgress, opts) {
     const total = results.length;
     const fetched = await mapPool(results, concurrency, async (tex, idx) => {
       const i = idx + 1;
-      const best = pickBestImage(tex.images || [], maxEdge);
+      const best = pickBestImage(tex.images || [], maxEdge, tex.pk);
       if (!best || !best.url) return null;
 
       const tuid = String(tex.uid || "").toLowerCase();

--- a/test/axis.test.js
+++ b/test/axis.test.js
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  axisRotationFor,
+  findAxisConversion,
+  isIdentityMat3,
+  mat3Multiply,
+  mat3Transpose,
+  ZUP_TO_YUP_MAT3,
+} from "../lib/osg-scene.js";
+
+const IDENTITY_MAT4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+// Sketchfab's wrapper for an uploaded glTF: Y-up content → the viewer's Z-up,
+// i.e. (x, y, z) → (x, -z, y). Column-major, as osgjs stores it.
+const YUP_TO_ZUP_MAT4 = [1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1];
+
+function rootedAt(matrix, name = "Wrapper") {
+  return {
+    "osg.Node": {
+      Children: [{ "osg.MatrixTransform": { Name: name, Matrix: matrix, Children: [] } }],
+    },
+  };
+}
+
+test("findAxisConversion spots a bare quarter turn about X", () => {
+  const node = findAxisConversion(rootedAt(YUP_TO_ZUP_MAT4));
+  assert.ok(node);
+  assert.equal(node.Name, "Wrapper");
+  // The opposite quarter turn is equally valid.
+  assert.ok(findAxisConversion(rootedAt([1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1])));
+});
+
+test("findAxisConversion ignores placement, scale and other axes", () => {
+  const turn = [1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0];
+  // Same rotation but translated — that is an object, not a conversion.
+  assert.equal(findAxisConversion(rootedAt([...turn, 5, 0, 0, 1])), null);
+  assert.equal(
+    findAxisConversion(rootedAt([2, 0, 0, 0, 0, 0, 2, 0, 0, -2, 0, 0, 0, 0, 0, 1])),
+    null
+  );
+  // Quarter turn about Z, not X.
+  assert.equal(
+    findAxisConversion(rootedAt([0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])),
+    null
+  );
+  assert.equal(findAxisConversion(rootedAt(IDENTITY_MAT4)), null);
+});
+
+test("findAxisConversion only considers the outermost transform", () => {
+  const tree = {
+    "osg.Node": {
+      Children: [
+        {
+          "osg.MatrixTransform": {
+            Name: "Placement",
+            Matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1],
+            Children: [
+              {
+                "osg.MatrixTransform": {
+                  Name: "Inner",
+                  Matrix: YUP_TO_ZUP_MAT4,
+                  Children: [],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+  assert.equal(findAxisConversion(tree), null);
+});
+
+test("findAxisConversion returns null for a scene with no transforms", () => {
+  assert.equal(findAxisConversion({ "osg.Node": { Children: [] } }), null);
+});
+
+test("a glTF-sourced model needs no turn: the wrapper already did it", () => {
+  const axis = axisRotationFor(rootedAt(YUP_TO_ZUP_MAT4));
+  assert.ok(axis.node);
+  assert.ok(isIdentityMat3(axis.matrix), `expected identity, got ${axis.matrix}`);
+});
+
+test("a Z-up model still gets the quarter turn", () => {
+  const axis = axisRotationFor(rootedAt([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 4, 0, 0, 1]));
+  assert.equal(axis.node, null);
+  assert.deepEqual(axis.matrix, ZUP_TO_YUP_MAT3);
+});
+
+test("the Z-up turn maps (x, y, z) to (x, z, -y)", () => {
+  const m = ZUP_TO_YUP_MAT3;
+  const apply = (v) => [
+    m[0] * v[0] + m[3] * v[1] + m[6] * v[2],
+    m[1] * v[0] + m[4] * v[1] + m[7] * v[2],
+    m[2] * v[0] + m[5] * v[1] + m[8] * v[2],
+  ];
+  assert.deepEqual(apply([1, 2, 3]), [1, 3, -2]);
+  // Height along +Z in a Z-up scene ends up along +Y, standing the model up.
+  assert.deepEqual(apply([0, 0, 1]), [0, 1, 0]);
+});
+
+test("transposing the axis rotation inverts it", () => {
+  const round = mat3Multiply(ZUP_TO_YUP_MAT3, mat3Transpose(ZUP_TO_YUP_MAT3));
+  assert.ok(isIdentityMat3(round));
+});

--- a/test/textures.test.js
+++ b/test/textures.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { pickBestImage } from "../lib/sf-api.js";
+import { isDescramblable, pickBestImage } from "../lib/sf-api.js";
 
 function im(w, h, extra = {}) {
   return { width: w, height: h, url: `${w}.jpg`, size: w * h, ...extra };
@@ -43,4 +43,78 @@ test("same resolution prefers PNG over JPEG", () => {
     im(2048, 2048, { url: "a.png", size: 800000 }),
   ]);
   assert.ok(best.url.endsWith(".png"));
+});
+
+// --- texture protection: only power-of-two variants can be descrambled ---
+
+test("a protected map that is not power-of-two loses to one that is", () => {
+  const best = pickBestImage([
+    { width: 800, height: 100, url: "orig.png", size: 12510, pk: 46634 },
+    { width: 512, height: 64, url: "pot.png", size: 23906, pk: 46634 },
+  ]);
+  assert.equal(best.width, 512);
+});
+
+test("the raw original is skipped even when it is a multiple of 8", () => {
+  // 1600x200 and 8000x1000 are both 8px-aligned but neither is power-of-two,
+  // and neither descrambles.
+  assert.equal(pickBestImage([
+    { width: 1600, height: 200, url: "a.png", size: 10, pk: 7 },
+    { width: 1024, height: 128, url: "b.png", size: 10, pk: 7 },
+  ]).width, 1024);
+  assert.equal(pickBestImage([
+    { width: 8000, height: 1000, url: "a.png", size: 10, pk: 7 },
+    { width: 4096, height: 512, url: "b.png", size: 10, pk: 7 },
+  ]).width, 4096);
+});
+
+test("unprotected maps are kept whatever their size", () => {
+  const best = pickBestImage([
+    { width: 800, height: 100, url: "big.png", size: 100, pk: null },
+    { width: 512, height: 64, url: "small.png", size: 100, pk: null },
+  ]);
+  assert.equal(best.width, 800);
+});
+
+test("all-unusable protected maps still return the largest rather than nothing", () => {
+  const best = pickBestImage([
+    { width: 800, height: 100, url: "a.png", size: 10, pk: 1 },
+    { width: 400, height: 50, url: "b.png", size: 10, pk: 1 },
+  ]);
+  assert.equal(best.width, 800);
+});
+
+test("a texture-level key still protects variants that omit their own", () => {
+  const best = pickBestImage(
+    [
+      { width: 800, height: 100, url: "big.png", size: 10 },
+      { width: 512, height: 64, url: "small.png", size: 10 },
+    ],
+    0,
+    46634
+  );
+  assert.equal(best.width, 512);
+});
+
+test("maxEdge still applies within the descramblable maps", () => {
+  const best = pickBestImage(
+    [
+      { width: 4096, height: 512, url: "a.png", size: 10, pk: 7 },
+      { width: 2048, height: 256, url: "b.png", size: 10, pk: 7 },
+      { width: 512, height: 64, url: "c.png", size: 10, pk: 7 },
+    ],
+    2048
+  );
+  assert.equal(best.width, 2048);
+});
+
+test("isDescramblable accepts only power-of-two protected maps", () => {
+  assert.equal(isDescramblable({ width: 2048, height: 256, pk: 5 }), true);
+  assert.equal(isDescramblable({ width: 4096, height: 512, pk: 5 }), true);
+  assert.equal(isDescramblable({ width: 8000, height: 1000, pk: 5 }), false);
+  assert.equal(isDescramblable({ width: 1600, height: 200, pk: 5 }), false);
+  assert.equal(isDescramblable({ width: 800, height: 100, pk: 5 }), false);
+  assert.equal(isDescramblable({ width: 1600, height: 201, pk: 5 }), false);
+  // no key means it was never scrambled, so size does not matter
+  assert.equal(isDescramblable({ width: 800, height: 100, pk: null }), true);
 });


### PR DESCRIPTION
Four changes to how the scene and its textures are read, ahead of a batch of converter work.

**Pick texture variants the protection shader can actually decode.** Sketchfab publishes several variants per texture; some are striped and only the viewer's shader can unpick them. The picker now prefers a variant the descrambler can handle rather than whichever the listing returned first.

**Keep both maps when two textures share a name.** Two different maps can arrive with the same basename, and the second was overwriting the first. They are now kept apart by uid.

**Derive the model's up-axis instead of assuming Z-up.** The converter hard-coded a Z-up rotation. Models that were not Z-up came out lying on their side. The axis now comes from the scene's own wrapper node, falling back to the old assumption when nothing says otherwise.

**Move the osgjs binary decoders into a shared module.** Pure refactor, no behaviour change — the binary readers were duplicated, and the later work in this series needs them in one place.

### Testing

`npm test` — 60 passing, up from 45. No new dependencies; the suite is still offline and dependency-free.

Output was also checked against the Khronos glTF validator on several real models, which is how the axis bug surfaced.

