### PR TITLE
Keep vertex colours, line geometry and per-material sided-ness

### DIFF
--- a/lib/osg-codec.js
+++ b/lib/osg-codec.js
@@ -1,0 +1,97 @@
+/**
+ * Low-level decoders for Sketchfab's osgjs binary payloads, ported from the
+ * viewer bundle.
+ *
+ * They live apart from the converter because more than one caller needs them,
+ * and because the spherical decoder in particular is easy to get subtly wrong.
+ */
+
+/** Varint stream → Int32Array/Uint32Array (zigzag-decoded when signed). */
+export function decodeVarint(bytes, count, typeName) {
+  const signed = typeName[0] !== "U";
+  const result = signed ? new Int32Array(count) : new Uint32Array(count);
+  let a = 0;
+  let o = 0;
+  while (a < count) {
+    let s = 0;
+    let l = 0;
+    do {
+      s |= (bytes[o] & 127) << l;
+      l += 7;
+    } while ((bytes[o++] & 128) !== 0);
+    result[a++] = s;
+  }
+  if (signed) {
+    for (let u = 0; u < count; u++) {
+      const c = result[u];
+      result[u] = (c >> 1) ^ -(c & 1); // zigzag decode
+    }
+  }
+  return result;
+}
+
+/** In-place zigzag delta decode from startIdx onwards. */
+export function deltaDecodeInPlace(arr, startIdx) {
+  const start = startIdx || 0;
+  let prev = arr[start];
+  for (let i = start + 1; i < arr.length; i++) {
+    const v = arr[i];
+    prev = arr[i] = prev + ((v >> 1) ^ -(v & 1));
+  }
+  return arr;
+}
+
+/** output[i][j] = bbl[j] + encoded[i][j] * h[j] */
+export function dequantize(encoded, output, bbl, h, itemSize) {
+  const count = encoded.length / itemSize;
+  for (let i = 0; i < count; i++) {
+    const base = i * itemSize;
+    for (let j = 0; j < itemSize; j++) {
+      output[base + j] = bbl[j] + encoded[base + j] * h[j];
+    }
+  }
+  return output;
+}
+
+/**
+ * Decode a direction on the unit sphere from two packed components.
+ *
+ * With itemSize 4 the fourth output is a tangent's handedness, which rides in
+ * bit 1024 of the first component.
+ */
+export function decodeSpherical(encoded, output, itemSize, epsilon, nphi, hasThirdComponent) {
+  epsilon = epsilon || 0.25;
+  nphi = nphi || 720;
+  const PI = 3.14159265359;
+  const cosEps = Math.cos(0.01745329251 * epsilon);
+  const dPhi = PI / (nphi - 1);
+  const dGamma = 1.57079632679 / (nphi - 1);
+  const stride = hasThirdComponent ? 3 : 2;
+  const count = encoded.length / stride;
+
+  for (let i = 0; i < count; i++) {
+    const outIdx = i * itemSize;
+    const inIdx = i * stride;
+    let S = encoded[inIdx];
+    const x = encoded[inIdx + 1];
+
+    if (itemSize === 4 && !hasThirdComponent) {
+      output[outIdx + 3] = S & 1024 ? -1 : 1;
+      S &= ~1024;
+    }
+
+    const A0 = S * dPhi;
+    const R = Math.cos(A0);
+    const w = Math.sin(A0);
+    const A1 = A0 + dGamma;
+    let E = (cosEps - R * Math.cos(A1)) / Math.max(1e-5, w * Math.sin(A1));
+    if (E > 1) E = 1;
+    else if (E < -1) E = -1;
+    const P = (6.28318530718 * x) / Math.ceil(PI / Math.max(1e-5, Math.acos(E)));
+
+    output[outIdx] = w * Math.cos(P);
+    output[outIdx + 1] = w * Math.sin(P);
+    output[outIdx + 2] = R;
+  }
+  return output;
+}

--- a/lib/osg-codec.js
+++ b/lib/osg-codec.js
@@ -2,8 +2,10 @@
  * Low-level decoders for Sketchfab's osgjs binary payloads, ported from the
  * viewer bundle.
  *
- * They live apart from the converter because more than one caller needs them,
- * and because the spherical decoder in particular is easy to get subtly wrong.
+ * Geometry attributes and animation curves share these primitives, so they
+ * live here rather than being duplicated: the spherical decoder in particular
+ * is easy to get subtly wrong, and the geometry path (normals/tangents) and
+ * the animation path (packed quaternions) exercise different branches of it.
  */
 
 /** Varint stream → Int32Array/Uint32Array (zigzag-decoded when signed). */
@@ -54,15 +56,67 @@ export function dequantize(encoded, output, bbl, h, itemSize) {
 }
 
 /**
- * Decode a direction on the unit sphere from two packed components.
+ * Planar → interleaved. Compressed streams store all X, then all Y, then all
+ * Z; every consumer wants them interleaved per item.
+ */
+export function deinterleave(src, dst, itemSize) {
+  const count = src.length / itemSize;
+  for (let i = 0; i < count; i++) {
+    const base = i * itemSize;
+    for (let j = 0; j < itemSize; j++) dst[base + j] = src[i + count * j];
+  }
+  return dst;
+}
+
+/** In-place prefix sum over items of `itemSize` components. */
+export function prefixSum(arr, itemSize) {
+  const n = itemSize || 1;
+  for (let i = 1, count = arr.length / n; i < count; i++) {
+    const prev = (i - 1) * n;
+    const cur = i * n;
+    for (let j = 0; j < n; j++) arr[cur + j] += arr[prev + j];
+  }
+  return arr;
+}
+
+/**
+ * In-place cumulative Hamilton product: q[i] = q[i-1] * q[i].
+ * Packed quaternion curves store deltas relative to the previous key.
+ */
+export function quatAccumulate(arr) {
+  for (let i = 1, count = arr.length / 4; i < count; i++) {
+    const p = 4 * (i - 1);
+    const c = 4 * i;
+    const ax = arr[p];
+    const ay = arr[p + 1];
+    const az = arr[p + 2];
+    const aw = arr[p + 3];
+    const bx = arr[c];
+    const by = arr[c + 1];
+    const bz = arr[c + 2];
+    const bw = arr[c + 3];
+    arr[c] = ax * bw + ay * bz - az * by + aw * bx;
+    arr[c + 1] = -ax * bz + ay * bw + az * bx + aw * by;
+    arr[c + 2] = ax * by - ay * bx + az * bw + aw * bz;
+    arr[c + 3] = -ax * bx - ay * by - az * bz + aw * bw;
+  }
+  return arr;
+}
+
+/**
+ * Spherical decoder shared by normals/tangents and packed quaternions.
  *
- * With itemSize 4 the fourth output is a tangent's handedness, which rides in
- * bit 1024 of the first component.
+ * Two encoded components address a point on the unit sphere. With
+ * `hasThirdComponent` a third component carries a half-angle, turning that
+ * direction into a unit quaternion (axis * sin, cos) — this is the form
+ * QuatSlerpChannelCompressed* uses. Without it, itemSize 4 means a tangent
+ * whose handedness rides in bit 1024 of the first component.
  */
 export function decodeSpherical(encoded, output, itemSize, epsilon, nphi, hasThirdComponent) {
   epsilon = epsilon || 0.25;
   nphi = nphi || 720;
   const PI = 3.14159265359;
+  const HALF_ANGLE_STEP = 4.7938362584151635e-5;
   const cosEps = Math.cos(0.01745329251 * epsilon);
   const dPhi = PI / (nphi - 1);
   const dGamma = 1.57079632679 / (nphi - 1);
@@ -89,9 +143,22 @@ export function decodeSpherical(encoded, output, itemSize, epsilon, nphi, hasThi
     else if (E < -1) E = -1;
     const P = (6.28318530718 * x) / Math.ceil(PI / Math.max(1e-5, Math.acos(E)));
 
-    output[outIdx] = w * Math.cos(P);
-    output[outIdx + 1] = w * Math.sin(P);
-    output[outIdx + 2] = R;
+    const dx = w * Math.cos(P);
+    const dy = w * Math.sin(P);
+    const dz = R;
+
+    if (hasThirdComponent) {
+      const half = HALF_ANGLE_STEP * encoded[inIdx + 2];
+      const s = Math.sin(half);
+      output[outIdx] = s * dx;
+      output[outIdx + 1] = s * dy;
+      output[outIdx + 2] = s * dz;
+      output[outIdx + 3] = Math.cos(half);
+    } else {
+      output[outIdx] = dx;
+      output[outIdx + 1] = dy;
+      output[outIdx + 2] = dz;
+    }
   }
   return output;
 }

--- a/lib/osg-scene.js
+++ b/lib/osg-scene.js
@@ -1,0 +1,122 @@
+/**
+ * Scene-graph queries over a parsed osgjs document, plus the small matrix
+ * helpers they hand back.
+ *
+ * The converter flattens the node tree, so anything the graph says about
+ * orientation has to be read out before that happens.
+ */
+
+/** Column-major 3x3s; the source → glTF axis fix is always a pure rotation. */
+export const IDENTITY_MAT3 = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
+/** The viewer's world is Z-up, glTF is Y-up: (x, y, z) → (x, z, -y). */
+export const ZUP_TO_YUP_MAT3 = [1, 0, 0, 0, 0, -1, 0, 1, 0];
+
+/** Column-major 3x3 product a x b (b applied first). */
+export function mat3Multiply(a, b) {
+  const out = new Array(9);
+  for (let c = 0; c < 3; c++) {
+    for (let r = 0; r < 3; r++) {
+      let sum = 0;
+      for (let k = 0; k < 3; k++) sum += a[k * 3 + r] * b[c * 3 + k];
+      out[c * 3 + r] = sum;
+    }
+  }
+  return out;
+}
+
+/** Rotation/scale block of a column-major 4x4. */
+export function mat3FromMat4(m) {
+  return [m[0], m[1], m[2], m[4], m[5], m[6], m[8], m[9], m[10]];
+}
+
+/** Widen a 3x3 to a 4x4 with no translation. */
+export function mat4FromMat3(m) {
+  return [m[0], m[1], m[2], 0, m[3], m[4], m[5], 0, m[6], m[7], m[8], 0, 0, 0, 0, 1];
+}
+
+export function mat3Transpose(m) {
+  return [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]];
+}
+
+export function isIdentityMat3(m) {
+  for (let i = 0; i < 9; i++) {
+    if (Math.abs(m[i] - IDENTITY_MAT3[i]) > 1e-6) return false;
+  }
+  return true;
+}
+
+/** Outermost node carrying a transform, in scene order. */
+function outermostTransform(node, depth) {
+  if (!node || typeof node !== "object" || depth > 40) return null;
+  if (Array.isArray(node)) {
+    for (const v of node) {
+      const hit = outermostTransform(v, depth + 1);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  for (const value of Object.values(node)) {
+    if (
+      value &&
+      typeof value === "object" &&
+      Array.isArray(value.Matrix) &&
+      value.Matrix.length === 16
+    ) {
+      return value;
+    }
+    const hit = outermostTransform(value, depth + 1);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** True for a bare quarter turn about X: no translation, no scale, no tilt. */
+function isQuarterTurnAboutX(m) {
+  const eps = 1e-4;
+  const near = (a, b) => Math.abs(a - b) <= eps;
+  if (!near(m[12], 0) || !near(m[13], 0) || !near(m[14], 0)) return false;
+  if (!near(m[0], 1) || !near(m[1], 0) || !near(m[2], 0)) return false;
+  const s = m[6];
+  if (!near(Math.abs(s), 1)) return false;
+  return (
+    near(m[4], 0) && near(m[5], 0) && near(m[8], 0) && near(m[9], -s) && near(m[10], 0)
+  );
+}
+
+/**
+ * Sketchfab's coordinate-conversion wrapper, when the model has one.
+ *
+ * An upload that arrived as glTF is Y-up, and Sketchfab wraps it in a single
+ * transform that turns it into the viewer's Z-up world. Everything below stays
+ * Y-up — the baked vertex data included — so a converter that assumes Z-up
+ * source would turn such a model twice and lay it on its side.
+ *
+ * Only the outermost transform is considered, and only when it is a bare
+ * quarter turn about X. Object placement carries translation or scale, and
+ * mistaking that for a conversion would tilt the model rather than stand it
+ * up; a model without a wrapper keeps the Z-up assumption.
+ *
+ * @returns {object|null} the conversion node, whose Matrix maps content → world
+ */
+export function findAxisConversion(osgjs) {
+  const node = outermostTransform(osgjs, 0);
+  if (!node || !isQuarterTurnAboutX(node.Matrix)) return null;
+  return node;
+}
+
+/**
+ * Rotation to bake into vertex data so the export lands in glTF's Y-up frame.
+ *
+ * Z-up source content needs a quarter turn. A model that arrived as glTF is
+ * already Y-up below the conversion wrapper, though, and turning it again lays
+ * it on its side — composing with that wrapper cancels the two out, which is
+ * why the rotation is derived rather than assumed.
+ *
+ * @returns {{matrix: number[], node: object|null}}
+ */
+export function axisRotationFor(osgjs) {
+  const node = findAxisConversion(osgjs);
+  const conv = node ? mat3FromMat4(node.Matrix) : IDENTITY_MAT3;
+  return { matrix: mat3Multiply(ZUP_TO_YUP_MAT3, conv), node };
+}

--- a/lib/osg-scene.js
+++ b/lib/osg-scene.js
@@ -12,6 +12,60 @@ export const IDENTITY_MAT3 = [1, 0, 0, 0, 1, 0, 0, 0, 1];
 /** The viewer's world is Z-up, glTF is Y-up: (x, y, z) → (x, z, -y). */
 export const ZUP_TO_YUP_MAT3 = [1, 0, 0, 0, 0, -1, 0, 1, 0];
 
+export const IDENTITY_MAT4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+/** Column-major 4x4 product a x b (b applied first). */
+export function mat4Multiply(a, b) {
+  const out = new Float64Array(16);
+  for (let c = 0; c < 4; c++) {
+    for (let r = 0; r < 4; r++) {
+      let sum = 0;
+      for (let k = 0; k < 4; k++) sum += a[k * 4 + r] * b[c * 4 + k];
+      out[c * 4 + r] = sum;
+    }
+  }
+  return out;
+}
+
+export function isIdentityMat4(m) {
+  if (!m) return true;
+  for (let i = 0; i < 16; i++) {
+    if (Math.abs(m[i] - IDENTITY_MAT4[i]) > 1e-9) return false;
+  }
+  return true;
+}
+
+/**
+ * Matrix for carrying normals through a placement: inverse transpose of the
+ * rotation/scale block.
+ *
+ * Rotating a normal by the placement itself is only right when the scale is
+ * uniform. Under a non-uniform scale the surface tilts one way and its normal
+ * the other, so reusing the placement would light the model wrongly. A
+ * singular block has no inverse; fall back to the block itself rather than
+ * emitting NaNs.
+ */
+export function normalMatrixFromMat4(m) {
+  const a = mat3FromMat4(m);
+  const det =
+    a[0] * (a[4] * a[8] - a[5] * a[7]) -
+    a[3] * (a[1] * a[8] - a[2] * a[7]) +
+    a[6] * (a[1] * a[5] - a[2] * a[4]);
+  if (!isFinite(det) || Math.abs(det) < 1e-12) return a;
+  const inv = [
+    (a[4] * a[8] - a[5] * a[7]) / det,
+    (a[2] * a[7] - a[1] * a[8]) / det,
+    (a[1] * a[5] - a[2] * a[4]) / det,
+    (a[5] * a[6] - a[3] * a[8]) / det,
+    (a[0] * a[8] - a[2] * a[6]) / det,
+    (a[2] * a[3] - a[0] * a[5]) / det,
+    (a[3] * a[7] - a[4] * a[6]) / det,
+    (a[1] * a[6] - a[0] * a[7]) / det,
+    (a[0] * a[4] - a[1] * a[3]) / det,
+  ];
+  return mat3Transpose(inv);
+}
+
 /** Column-major 3x3 product a x b (b applied first). */
 export function mat3Multiply(a, b) {
   const out = new Array(9);

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -251,7 +251,7 @@ function readBufferArray(binData, vb, typeName) {
     return new TypedArr(binData, offset, size * itemSize);
 }
 
-function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, placement) {
+function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, placement, opts = {}) {
     const userData = sharedState || {};
     const result = { name: geom.Name || 'unnamed', attributes: {}, indices: null, mode: 'TRIANGLES', material: null };
     const meta = {};
@@ -328,7 +328,11 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, plac
     }
 
     // Process vertex attributes
-    if (!result.indices) return result;
+    //
+    // A geometry with no triangles is normally not worth reading. A morph
+    // target is the exception: it carries only vertex data and borrows its
+    // topology from the mesh it belongs to.
+    if (!result.indices && !opts.attributesOnly) return result;
     const vaList = geom.VertexAttributeList || {};
     for (const [attrName, attrDef] of Object.entries(vaList)) {
         const arrInfo = attrDef.Array;
@@ -1296,6 +1300,14 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
 
     const meshNodes = [];
     const skinnedMeshNodes = [];
+    /**
+     * Morph target name -> which mesh node it belongs to and its slot in that
+     * mesh's target list. osgjs drives each target with its own scalar channel;
+     * glTF wants one channel per mesh carrying every weight, so the curves have
+     * to be regrouped by node before they can be written.
+     */
+    const morphTargetIndex = new Map();
+
     let geomI = 0;
     for (const geom of geometries) {
         if (!geom.indices || !geom.attributes.POSITION) { geomI++; continue; }
@@ -1357,9 +1369,39 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         // multi-primitive mesh is flaky; separate objects import textures reliably.
         const meshIdx = gltf.meshes.length;
         const meshName = (geom.name || matName || ('Mesh_' + geomI)).slice(0, 64);
-        gltf.meshes.push({ name: meshName, primitives: [primitive] });
+        const mesh = { name: meshName, primitives: [primitive] };
+        if (geom.morphTargets && geom.morphTargets.length) {
+            primitive.targets = geom.morphTargets.map((t) => {
+                const entry = {
+                    POSITION: addAccessor(t.POSITION, 'VEC3', 5126, t.count, 3, false),
+                };
+                if (t.NORMAL) {
+                    entry.NORMAL = addAccessor(t.NORMAL, 'VEC3', 5126, t.count, 3, false);
+                }
+                return entry;
+            });
+            // Weights start at rest. The viewer's own resting values are not in
+            // the scene graph, and an animation overrides them anyway.
+            mesh.weights = geom.morphTargets.map(() => 0);
+            mesh.extras = {
+                ...(mesh.extras || {}),
+                targetNames: geom.morphTargets.map((t, i) => t.name || `target_${i}`),
+            };
+        }
+        gltf.meshes.push(mesh);
         const nodeIdx = gltf.nodes.length;
         gltf.nodes.push({ name: meshName, mesh: meshIdx });
+        if (geom.morphTargets) {
+            geom.morphTargets.forEach((t, i) => {
+                if (t.name && !morphTargetIndex.has(t.name)) {
+                    morphTargetIndex.set(t.name, {
+                        node: nodeIdx,
+                        index: i,
+                        count: geom.morphTargets.length,
+                    });
+                }
+            });
+        }
         meshNodes.push(nodeIdx);
         if (geom.boneMap) skinnedMeshNodes.push([nodeIdx, geom]);
         geomI++;
@@ -1526,7 +1568,16 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
     for (const anim of options.animationCurves || []) {
         const samplers = [];
         const channels = [];
+        const weightsByNode = new Map();
         for (const curve of anim.curves) {
+            if (curve.path === 'weights') {
+                const slot = morphTargetIndex.get(curve.target);
+                if (!slot) continue;
+                const list = weightsByNode.get(slot.node) || { count: slot.count, entries: [] };
+                list.entries.push({ index: slot.index, curve });
+                weightsByNode.set(slot.node, list);
+                continue;
+            }
             const nodeIdx = animTargetIndex.get(curve.target);
             if (nodeIdx === undefined) continue;
             const input = addTimeAccessor(curve.times);
@@ -1543,6 +1594,20 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             channels.push({
                 sampler: samplers.length - 1,
                 target: { node: nodeIdx, path: curve.path },
+            });
+        }
+        for (const [nodeIdx, group] of weightsByNode) {
+            const merged = mergeWeightCurves(group.entries, group.count);
+            if (!merged) continue;
+            const input = addTimeAccessor(merged.times);
+            const output = addAccessor(
+                merged.values, 'SCALAR', 5126, merged.values.length, 1, false,
+                { noStride: true, noMinMax: true }
+            );
+            samplers.push({ input, output, interpolation: 'LINEAR' });
+            channels.push({
+                sampler: samplers.length - 1,
+                target: { node: nodeIdx, path: 'weights' },
             });
         }
         if (channels.length) {
@@ -1700,6 +1765,104 @@ function extractMeshGeometry(wrapper) {
     return null;
 }
 
+/**
+ * Shape-key geometry hanging off a MorphGeometry, as glTF morph targets.
+ *
+ * osgjs stores each target as a complete replacement mesh, while glTF wants
+ * displacements from the base, so the base is subtracted out. Both sides go
+ * through the same placement and axis handling first; the two transforms then
+ * cancel in the subtraction, leaving the displacement in the right frame.
+ *
+ * A target whose vertex count does not match the base is skipped rather than
+ * guessed at: glTF cannot express a target of a different size, and a
+ * mismatched one would corrupt the mesh.
+ */
+function readMorphTargets(morphNode, base, polyBin, wireBin, axisRotation, placement) {
+    const entries = morphNode.MorphTargets || [];
+    const basePos = base.attributes.POSITION;
+    if (!basePos || !entries.length) return [];
+    const baseNormal = base.attributes.NORMAL;
+    const out = [];
+    for (const entry of entries) {
+        if (!entry || typeof entry !== 'object') continue;
+        const geom = entry['osg.Geometry'] || (entry.VertexAttributeList ? entry : null);
+        if (!geom || !geom.VertexAttributeList) continue;
+        let target;
+        try {
+            target = processGeometry(
+                geom, polyBin, wireBin, {}, axisRotation, placement,
+                { attributesOnly: true }
+            );
+        } catch (e) {
+            continue;
+        }
+        const pos = target.attributes.POSITION;
+        if (!pos || pos.count !== basePos.count) continue;
+        const deltaPos = new Float32Array(basePos.count * 3);
+        for (let i = 0; i < deltaPos.length; i++) {
+            deltaPos[i] = pos.data[i] - basePos.data[i];
+        }
+        const rec = { name: geom.Name || '', POSITION: deltaPos, count: basePos.count };
+        const nrm = target.attributes.NORMAL;
+        if (baseNormal && nrm && nrm.count === baseNormal.count) {
+            const deltaNrm = new Float32Array(baseNormal.count * 3);
+            for (let i = 0; i < deltaNrm.length; i++) {
+                deltaNrm[i] = nrm.data[i] - baseNormal.data[i];
+            }
+            rec.NORMAL = deltaNrm;
+        }
+        out.push(rec);
+    }
+    return out;
+}
+
+/** Linear read of a scalar curve at an arbitrary time, clamped at the ends. */
+export function sampleScalar(times, values, t) {
+    const n = times.length;
+    if (!n) return 0;
+    if (t <= times[0]) return values[0];
+    if (t >= times[n - 1]) return values[n - 1];
+    let lo = 0;
+    let hi = n - 1;
+    while (hi - lo > 1) {
+        const mid = (lo + hi) >> 1;
+        if (times[mid] <= t) lo = mid;
+        else hi = mid;
+    }
+    const span = times[hi] - times[lo];
+    const f = span > 0 ? (t - times[lo]) / span : 0;
+    return values[lo] + (values[hi] - values[lo]) * f;
+}
+
+/**
+ * One glTF weights sampler from a mesh's separate per-target curves.
+ *
+ * glTF interleaves every target's weight into a single output, so all the
+ * curves have to share one timeline. Each keeps its own key times in osgjs,
+ * so the union is taken and the curves that do not have a key there are
+ * read at that instant instead. A target with no curve at all stays at
+ * rest rather than being dropped, which would shift the remaining weights
+ * onto the wrong targets.
+ */
+export function mergeWeightCurves(entries, targetCount) {
+    const timeSet = new Set();
+    for (const e of entries) {
+        for (const t of e.curve.times) timeSet.add(t);
+    }
+    const times = [...timeSet].sort((a, b) => a - b);
+    if (!times.length) return null;
+    const values = new Float32Array(times.length * targetCount);
+    for (const e of entries) {
+        if (e.index < 0 || e.index >= targetCount) continue;
+        for (let i = 0; i < times.length; i++) {
+            values[i * targetCount + e.index] = sampleScalar(
+                e.curve.times, e.curve.values, times[i]
+            );
+        }
+    }
+    return { times: Float32Array.from(times), values };
+}
+
 function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
     const uidMap = {};
     buildUidMap(node, uidMap);
@@ -1710,7 +1873,7 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
     const sharedState = { expectedState: [0] };
     const stats = { rig: 0, geom: 0, morph: 0, wire: 0, skip: 0, errors: [] };
 
-    function acceptGeometry(geom, label, rig, placement) {
+    function acceptGeometry(geom, label, rig, placement, morphNode) {
         if (!geom) return;
         if (isWireframeGeom(geom)) {
             stats.wire++;
@@ -1738,6 +1901,12 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
                 for (const k of tcKeys) {
                     result.attributes[`TEXCOORD_${tcIdx++}`] = result.attributes[k];
                     delete result.attributes[k];
+                }
+                if (morphNode) {
+                    const targets = readMorphTargets(
+                        morphNode, result, polyBin, wireBin, axisRotation, placement
+                    );
+                    if (targets.length) result.morphTargets = targets;
                 }
                 if (rig) {
                     const skinAttrs = readRigAttributes(
@@ -1810,7 +1979,7 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
             const morph = obj['osgAnimation.MorphGeometry'] || obj['osg.MorphGeometry'];
             stats.morph++;
             const mesh = extractMeshGeometry(morph) || morph;
-            acceptGeometry(mesh, 'MorphGeometry', null, acc);
+            acceptGeometry(mesh, 'MorphGeometry', null, acc, morph);
             for (const [k, v] of Object.entries(obj)) {
                 if (k === 'osgAnimation.MorphGeometry' || k === 'osg.MorphGeometry') continue;
                 walk(v, depth + 1, placementOf(v, acc));

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -21,6 +21,8 @@ import {
     collectSkeletons,
     collectAnimations,
     decodeChannelCurve,
+    stackedTRS,
+    stripNonIncreasingKeys,
 } from './skin.js';
 
 // --- Browser helpers (Uint8Array instead of Node Buffer) ---
@@ -476,7 +478,7 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, plac
     // Placement is in the viewer's own frame, so it has to land before the
     // model is turned into glTF's.
     applyPlacement(result, placement);
-    applyAxisRotation(result, axisRotation);
+    if (!opts.skipAxis) applyAxisRotation(result, axisRotation);
 
     return result;
 }
@@ -1298,8 +1300,67 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
     // Ensure at least one material exists (fallback if no meshes pass filters)
     if (!textureMap) textureMap = null;
 
+    const axisRotation = options.axisRotation || ZUP_TO_YUP_MAT3;
+    const AXIS_MAT4 = mat4FromMat3(axisRotation);
+    const AXIS_INVERSE_MAT4 = mat4FromMat3(mat3Transpose(axisRotation));
+
     const meshNodes = [];
     const skinnedMeshNodes = [];
+    /**
+     * Separate from boneNodeIndex on purpose. Skin binding resolves names out
+     * of a RigGeometry's BoneMap and must keep matching bone names exactly;
+     * adding animation aliases to that map risks binding a mesh to the wrong
+     * joint. Animation targets get their own lookup.
+     */
+    const animTargetIndex = new Map();
+    /** Nodes for animated transforms, built on demand and shared by every mesh under one. */
+    const animNodeByCtx = new Map();
+    const animRootNodes = [];
+
+    /**
+     * The glTF node an animated transform becomes, creating it and its parents
+     * if this is the first mesh to need them.
+     *
+     * The chain mirrors the scene: a static offset node carrying whatever sat
+     * between this transform and the one above it, then the transform itself
+     * holding the resting TRS an animation will overwrite. The outermost offset
+     * also carries the axis fix, which meshes below here deliberately do not
+     * bake into their vertices.
+     */
+    function nodeForAnimCtx(ctx) {
+        if (!ctx) return -1;
+        const cached = animNodeByCtx.get(ctx);
+        if (cached !== undefined) return cached;
+
+        const parentIdx = ctx.parent ? nodeForAnimCtx(ctx.parent) : -1;
+        const offset = ctx.parent ? ctx.pre : mat4Multiply(AXIS_MAT4, ctx.pre);
+        let anchor = parentIdx;
+        if (!isIdentityMat4(offset)) {
+            const idx = gltf.nodes.length;
+            gltf.nodes.push({
+                name: `${ctx.name || 'Animated'}_placement`,
+                matrix: Array.from(offset),
+                children: [],
+            });
+            if (anchor >= 0) gltf.nodes[anchor].children.push(idx);
+            else animRootNodes.push(idx);
+            anchor = idx;
+        }
+
+        const idx = gltf.nodes.length;
+        const node = { name: ctx.name || 'Animated', children: [] };
+        const trs = ctx.trs || {};
+        if (trs.translation) node.translation = Array.from(trs.translation);
+        if (trs.rotation) node.rotation = Array.from(trs.rotation);
+        if (trs.scale) node.scale = Array.from(trs.scale);
+        gltf.nodes.push(node);
+        if (anchor >= 0) gltf.nodes[anchor].children.push(idx);
+        else animRootNodes.push(idx);
+
+        animNodeByCtx.set(ctx, idx);
+        if (ctx.name && !animTargetIndex.has(ctx.name)) animTargetIndex.set(ctx.name, idx);
+        return idx;
+    }
     /**
      * Morph target name -> which mesh node it belongs to and its slot in that
      * mesh's target list. osgjs drives each target with its own scalar channel;
@@ -1402,7 +1463,9 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 }
             });
         }
-        meshNodes.push(nodeIdx);
+        const animParent = geom.animCtx ? nodeForAnimCtx(geom.animCtx) : -1;
+        if (animParent >= 0) gltf.nodes[animParent].children.push(nodeIdx);
+        else meshNodes.push(nodeIdx);
         if (geom.boneMap) skinnedMeshNodes.push([nodeIdx, geom]);
         geomI++;
     }
@@ -1418,9 +1481,6 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
     // than on the bone itself, so that the bone's own transform stays free.
     // Vertices arrive already rotated, so the inverse bind matrices undo it
     // before binding.
-    const axisRotation = options.axisRotation || ZUP_TO_YUP_MAT3;
-    const AXIS_MAT4 = mat4FromMat3(axisRotation);
-    const AXIS_INVERSE_MAT4 = mat4FromMat3(mat3Transpose(axisRotation));
 
     /** Column-major 4x4 product a x b (b applied first). */
     function mat4Multiply(a, b) {
@@ -1437,13 +1497,6 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
 
     const skeletonData = options.skeletons || null;
     const boneNodeIndex = new Map();
-    /**
-     * Separate from boneNodeIndex on purpose. Skin binding resolves names out
-     * of a RigGeometry's BoneMap and must keep matching bone names exactly;
-     * adding animation aliases to that map risks binding a mesh to the wrong
-     * joint. Animation targets get their own lookup.
-     */
-    const animTargetIndex = new Map();
     const rigRootNodes = [];
     const rigRootBySkeleton = new Map();
 
@@ -1580,12 +1633,13 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             }
             const nodeIdx = animTargetIndex.get(curve.target);
             if (nodeIdx === undefined) continue;
-            const input = addTimeAccessor(curve.times);
+            const keys = stripNonIncreasingKeys(curve.times, curve.values, curve.itemSize);
+            const input = addTimeAccessor(keys.times);
             const output = addAccessor(
-                curve.values,
+                keys.values,
                 `VEC${curve.itemSize}`,
                 5126,
-                curve.times.length,
+                keys.times.length,
                 curve.itemSize,
                 false,
                 { noStride: true, noMinMax: true }
@@ -1615,12 +1669,12 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         }
     }
 
-    if (meshNodes.length) {
+    if (meshNodes.length || animRootNodes.length) {
         // Vertices carry the axis fix already; the parent keeps the official name.
         const root = gltf.nodes.length;
         gltf.nodes.push({
             name: 'Sketchfab_model',
-            children: meshNodes.concat(rigRootNodes),
+            children: meshNodes.concat(rigRootNodes, animRootNodes),
         });
         gltf.scenes[0].nodes = [root];
     } else {
@@ -1777,7 +1831,7 @@ function extractMeshGeometry(wrapper) {
  * guessed at: glTF cannot express a target of a different size, and a
  * mismatched one would corrupt the mesh.
  */
-function readMorphTargets(morphNode, base, polyBin, wireBin, axisRotation, placement) {
+function readMorphTargets(morphNode, base, polyBin, wireBin, axisRotation, placement, skipAxis) {
     const entries = morphNode.MorphTargets || [];
     const basePos = base.attributes.POSITION;
     if (!basePos || !entries.length) return [];
@@ -1791,7 +1845,7 @@ function readMorphTargets(morphNode, base, polyBin, wireBin, axisRotation, place
         try {
             target = processGeometry(
                 geom, polyBin, wireBin, {}, axisRotation, placement,
-                { attributesOnly: true }
+                { attributesOnly: true, skipAxis }
             );
         } catch (e) {
             continue;
@@ -1863,6 +1917,28 @@ export function mergeWeightCurves(entries, targetCount) {
     return { times: Float32Array.from(times), values };
 }
 
+/**
+ * A transform an animation drives, as opposed to one that merely places
+ * something.
+ *
+ * Bones are excluded: they carry osgAnimation.UpdateBone and belong to the
+ * skeleton path, which already owns their placement. Only a transform with an
+ * UpdateMatrixTransform, and a name for a channel to address it by, is one an
+ * object animation can target.
+ *
+ * @returns {object|null} the update callback, or null if nothing drives it
+ */
+export function animatedTransform(value) {
+    if (!value || typeof value !== 'object') return null;
+    for (const cb of value.UpdateCallbacks || []) {
+        if (!cb || typeof cb !== 'object') continue;
+        if (Object.keys(cb)[0] !== 'osgAnimation.UpdateMatrixTransform') continue;
+        const update = cb['osgAnimation.UpdateMatrixTransform'];
+        if (update && update.Name) return update;
+    }
+    return null;
+}
+
 function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
     const uidMap = {};
     buildUidMap(node, uidMap);
@@ -1873,7 +1949,7 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
     const sharedState = { expectedState: [0] };
     const stats = { rig: 0, geom: 0, morph: 0, wire: 0, skip: 0, errors: [] };
 
-    function acceptGeometry(geom, label, rig, placement, morphNode) {
+    function acceptGeometry(geom, label, rig, placement, morphNode, animCtx) {
         if (!geom) return;
         if (isWireframeGeom(geom)) {
             stats.wire++;
@@ -1889,9 +1965,17 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
         try {
             // A skinned mesh is positioned by its skeleton, so placement is only
             // baked for meshes that have no other way to get it.
+            //
+            // Under an animated node the axis fix moves onto that node's
+            // wrapper: baking it into the vertices as well would apply it
+            // twice, once here and once through the parent.
+            const underAnimated = !!animCtx && !rig;
             const result = processGeometry(
-                geom, polyBin, wireBin, sharedState, axisRotation, rig ? null : placement
+                geom, polyBin, wireBin, sharedState, axisRotation,
+                rig ? null : placement,
+                { skipAxis: underAnimated }
             );
+            if (underAnimated) result.animCtx = animCtx;
             if (result.indices && result.attributes.POSITION) {
                 // Remap _TC_* to continuous TEXCOORD_0, TEXCOORD_1, ...
                 const tcKeys = Object.keys(result.attributes)
@@ -1904,7 +1988,8 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
                 }
                 if (morphNode) {
                     const targets = readMorphTargets(
-                        morphNode, result, polyBin, wireBin, axisRotation, placement
+                        morphNode, result, polyBin, wireBin, axisRotation, placement,
+                        underAnimated
                     );
                     if (targets.length) result.morphTargets = targets;
                 }
@@ -1948,11 +2033,29 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
         return mat4Multiply(acc, value.Matrix);
     }
 
-    function walk(obj, depth, acc) {
+    /**
+     * Descend one level, returning the placement to bake and the animated node
+     * a mesh below here belongs to.
+     *
+     * Baking an animated node's transform into vertices would freeze it, so the
+     * accumulation restarts underneath one: what has been gathered so far
+     * becomes that node's own offset, and only transforms below it keep being
+     * baked.
+     */
+    function descend(value, acc, ctx) {
+        const update = value === axisNode ? null : animatedTransform(value);
+        if (!update) return [placementOf(value, acc), ctx];
+        return [
+            IDENTITY_MAT4,
+            { name: update.Name, trs: stackedTRS(value), pre: acc, parent: ctx, node: -1 },
+        ];
+    }
+
+    function walk(obj, depth, acc, ctx) {
         if (!obj || typeof obj !== 'object' || depth > 60) return;
 
         if (Array.isArray(obj)) {
-            for (const item of obj) walk(item, depth + 1, acc);
+            for (const item of obj) walk(item, depth + 1, acc, ctx);
             return;
         }
 
@@ -1961,15 +2064,15 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
             const rig = obj['osgAnimation.RigGeometry'] || obj['osg.RigGeometry'];
             stats.rig++;
             const mesh = extractMeshGeometry(rig);
-            acceptGeometry(mesh, 'RigGeometry', rig, acc);
+            acceptGeometry(mesh, 'RigGeometry', rig, acc, null, ctx);
             // Walk other fields except SourceGeometry (already handled)
             for (const [k, v] of Object.entries(rig)) {
                 if (k === 'SourceGeometry') continue;
-                walk(v, depth + 1, placementOf(v, acc));
+                { const [a2, c2] = descend(v, acc, ctx); walk(v, depth + 1, a2, c2); }
             }
             for (const [k, v] of Object.entries(obj)) {
                 if (k === 'osgAnimation.RigGeometry' || k === 'osg.RigGeometry') continue;
-                walk(v, depth + 1, placementOf(v, acc));
+                { const [a2, c2] = descend(v, acc, ctx); walk(v, depth + 1, a2, c2); }
             }
             return;
         }
@@ -1979,30 +2082,31 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
             const morph = obj['osgAnimation.MorphGeometry'] || obj['osg.MorphGeometry'];
             stats.morph++;
             const mesh = extractMeshGeometry(morph) || morph;
-            acceptGeometry(mesh, 'MorphGeometry', null, acc, morph);
+            acceptGeometry(mesh, 'MorphGeometry', null, acc, morph, ctx);
             for (const [k, v] of Object.entries(obj)) {
                 if (k === 'osgAnimation.MorphGeometry' || k === 'osg.MorphGeometry') continue;
-                walk(v, depth + 1, placementOf(v, acc));
+                { const [a2, c2] = descend(v, acc, ctx); walk(v, depth + 1, a2, c2); }
             }
             // still walk morph internals except duplicate source
             for (const [k, v] of Object.entries(morph)) {
                 if (k === 'SourceGeometry') continue;
-                walk(v, depth + 1, placementOf(v, acc));
+                { const [a2, c2] = descend(v, acc, ctx); walk(v, depth + 1, a2, c2); }
             }
             return;
         }
 
         if (obj['osg.Geometry']) {
             stats.geom++;
-            acceptGeometry(obj['osg.Geometry'], 'Geometry', null, acc);
+            acceptGeometry(obj['osg.Geometry'], 'Geometry', null, acc, null, ctx);
         }
 
         for (const v of Object.values(obj)) {
-            walk(v, depth + 1, placementOf(v, acc));
+            const [a2, c2] = descend(v, acc, ctx);
+            walk(v, depth + 1, a2, c2);
         }
     }
 
-    walk(node, 0, IDENTITY_MAT4);
+    walk(node, 0, IDENTITY_MAT4, null);
 
     if (!results.length) {
         const errBits = [

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -345,6 +345,18 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, plac
         const drawType = Object.keys(prim)[0];
         const draw = prim[drawType];
         const idxInfo = draw.Indices;
+        /**
+         * A point cloud draws straight from the vertex array: DrawArrays with
+         * mode POINTS and no index buffer at all. Sketchfab accepts and renders
+         * these, so the converter refusing them was a gap rather than a
+         * limitation -- glTF expresses the same thing as a non-indexed
+         * primitive with mode 0.
+         */
+        if (draw.Mode === 'POINTS') {
+            result.mode = 'POINTS';
+            result.pointCount = (result.pointCount || 0) + (draw.Count || 0);
+            continue;
+        }
         if (!idxInfo) continue;
         if (draw.Mode !== 'TRIANGLE_STRIP' && draw.Mode !== 'TRIANGLES') continue;
 
@@ -397,7 +409,7 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, plac
     // A geometry with no triangles is normally not worth reading. A morph
     // target is the exception: it carries only vertex data and borrows its
     // topology from the mesh it belongs to.
-    if (!result.indices && !opts.attributesOnly) return result;
+    if (!result.indices && result.mode !== 'POINTS' && !opts.attributesOnly) return result;
     const vaList = geom.VertexAttributeList || {};
     for (const [attrName, attrDef] of Object.entries(vaList)) {
         const arrInfo = attrDef.Array;
@@ -492,6 +504,21 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, plac
             // baseColorTexture * COLOR_0, which makes textured models look
             // untextured / transparent / wrong. True vertex-color meshes are rare
             // on Sketchfab viewer data.
+            //
+            // A point cloud is the exception, and not a marginal one: it has no
+            // triangles, no UVs and no textures, so per-vertex colour is the
+            // only surface information in the file. Dropping it leaves a grey
+            // blob.
+            if (result.mode === 'POINTS') {
+                const isFloat = data instanceof Float32Array;
+                result.attributes.COLOR_0 = {
+                    data,
+                    itemSize,
+                    count,
+                    componentType: isFloat ? 5126 : 5121,
+                    normalized: !isFloat,
+                };
+            }
         }
     }
 
@@ -1499,7 +1526,10 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
 
     let geomI = 0;
     for (const geom of geometries) {
-        if (!geom.indices || !geom.attributes.POSITION) { geomI++; continue; }
+        // A point cloud has no index buffer by construction, so "no indices"
+        // is only a reason to skip when the geometry claimed to be triangles.
+        const isPoints = geom.mode === 'POINTS';
+        if ((!geom.indices && !isPoints) || !geom.attributes.POSITION) { geomI++; continue; }
 
         const map = (perGeomMaps && perGeomMaps[geomI]) || textureMap;
         // Skip glass / invisible rim shells (viewer opacity 0 or additive ghost)
@@ -1515,12 +1545,14 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             ('Material_' + geomI);
         const matIdx = materialIndexFor(map, matName, geom.uvUnits);
 
-        const primitive = { attributes: {}, material: matIdx, mode: 4 };
+        const primitive = { attributes: {}, material: matIdx, mode: isPoints ? 0 : 4 };
 
         // Indices
-        const idx = geom.indices;
-        const idxType = idx.BYTES_PER_ELEMENT === 4 ? 5125 : 5123;
-        primitive.indices = addAccessor(idx, 'SCALAR', idxType, idx.length, 1);
+        if (!isPoints) {
+            const idx = geom.indices;
+            const idxType = idx.BYTES_PER_ELEMENT === 4 ? 5125 : 5123;
+            primitive.indices = addAccessor(idx, 'SCALAR', idxType, idx.length, 1);
+        }
 
         // Attributes — only standard glTF attribute names (skip junk COLOR_0 already)
         for (const [name, attr] of Object.entries(geom.attributes)) {
@@ -1539,7 +1571,9 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         }
 
         // Safety: if no TEXCOORD_0 but material uses textures, Blender won't show maps
+        // (a point cloud has no UVs and no textures, so there is nothing to bind)
         if (
+            !isPoints &&
             !primitive.attributes.TEXCOORD_0 &&
             map &&
             (map.albedo || map.normal || map.metalness)
@@ -1551,8 +1585,10 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         }
 
         // Remove byteStride from index bufferViews (safety)
-        const idxBV = gltf.accessors[primitive.indices].bufferView;
-        delete gltf.bufferViews[idxBV].byteStride;
+        if (primitive.indices !== undefined) {
+            const idxBV = gltf.accessors[primitive.indices].bufferView;
+            delete gltf.bufferViews[idxBV].byteStride;
+        }
 
         // One mesh + node per geometry — Blender multi-material on a single
         // multi-primitive mesh is flaky; separate objects import textures reliably.
@@ -2104,7 +2140,7 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
                 { skipAxis: underAnimated }
             );
             if (underAnimated) result.animCtx = animCtx;
-            if (result.indices && result.attributes.POSITION) {
+            if ((result.indices || result.mode === 'POINTS') && result.attributes.POSITION) {
                 // Remap _TC_* to continuous TEXCOORD_0, TEXCOORD_1, ...
                 //
                 // Sorted numerically, not lexicographically: the suffix is a

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -407,6 +407,7 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, plac
     // loose-triangle set continues from the same value. A fresh counter per
     // primitive corrupts the loose-triangle indices.
     const expState = [0];
+    const lineChunks = [];
     for (const prim of primList) {
         const drawType = Object.keys(prim)[0];
         const draw = prim[drawType];
@@ -424,14 +425,41 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, plac
             continue;
         }
         if (!idxInfo) continue;
-        if (draw.Mode !== 'TRIANGLE_STRIP' && draw.Mode !== 'TRIANGLES') continue;
+        const isLines = draw.Mode === 'LINES';
+        if (!isLines && draw.Mode !== 'TRIANGLE_STRIP' && draw.Mode !== 'TRIANGLES') continue;
 
         const arrInfo = idxInfo.Array;
         const arrType = Object.keys(arrInfo)[0];
         const arrDef = arrInfo[arrType];
         const isWireframe = arrDef.File && arrDef.File.includes('wireframe');
+        /**
+         * Sketchfab draws a LINES wireframe overlay for every geometry,
+         * authored or not. The copy shares the parent's vertices and keeps only
+         * its own index array, in model_file_wireframe.binz; genuine line
+         * geometry indexes out of model_file.binz. That is the whole difference
+         * between an authored wireframe cube and the viewer's own overlay, and
+         * accepting LINES without checking it would give every triangle mesh a
+         * duplicate made of edges.
+         */
+        if (isLines && isWireframe) continue;
         const binSrc = isWireframe ? wireBin : polyBin;
         if (!binSrc) continue;
+
+        /**
+         * Line indices are used as they are. Sketchfab expands LINE_STRIP and
+         * LINE_LOOP into explicit segments on import -- a 49-point strip
+         * arrives as 96 indices, a 5-point loop as 10 with the closing edge
+         * already present -- so mode 1 is the only line mode that ever reaches
+         * here, and there is no strip to unroll or loop to close.
+         */
+        if (isLines) {
+            result.mode = 'LINES';
+            const li = widenIndices(
+                readBufferArray(asArrayBuffer(binSrc), { ...arrDef, ItemSize: 1 }, arrType)
+            );
+            lineChunks.push(li);
+            continue;
+        }
 
         const isStrip = draw.Mode === 'TRIANGLE_STRIP';
         let indices = widenIndices(readBufferArray(asArrayBuffer(binSrc), { ...arrDef, ItemSize: 1 }, arrType));
@@ -457,6 +485,17 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, plac
             triChunks.push(triStripToTriangles(out));
         } else {
             triChunks.push(looseTrianglesToTriangles(out));
+        }
+    }
+
+    if (result.mode === 'LINES') {
+        let n = 0;
+        for (const c of lineChunks) n += c.length;
+        if (n) {
+            const merged = new Uint32Array(n);
+            let o = 0;
+            for (const c of lineChunks) { merged.set(c, o); o += c.length; }
+            result.indices = merged;
         }
     }
 
@@ -923,10 +962,22 @@ export function chooseAlbedoName(albedoName, specularName, textureList) {
 }
 
 /** Empty hair/line shells with no albedo AND no opacity atlas. */
-export function shouldSkipUntexturedShell(spec, matName, geomName) {
+export function shouldSkipUntexturedShell(spec, matName, geomName, mode) {
     if (!spec) return false;
     if (spec.skipMesh) return true;
     if (spec.albedoUid || spec.opacityUid) return false;
+    /**
+     * The name test below drops untextured hair and eyelash cards, and "line"
+     * earns its place there because those shells are usually named for the
+     * lines they draw. Genuine line geometry matches it by definition -- a
+     * material called ML01_Lines on a mesh made of edges is the true positive
+     * the heuristic was never meant to catch -- and lines carry no albedo, so
+     * every one of them would be dropped as a shell.
+     *
+     * An invisible or glass mesh is still skipped above; only the name guess
+     * is scoped to triangles.
+     */
+    if (mode === 'LINES' || mode === 'POINTS') return false;
     return /hair|line|brow|lash/i.test(String(matName || geomName || ''));
 }
 
@@ -1077,7 +1128,7 @@ function buildTextureMaps(geometries, textureList, textureFiles, viewerMaterials
         }
         if (found && found.spec) {
             const spec = found.spec;
-            if (shouldSkipUntexturedShell(spec, matName, geom.name)) {
+            if (shouldSkipUntexturedShell(spec, matName, geom.name, geom.mode)) {
                 return { skip: true };
             }
             let albedo = resolveUidToBase(spec.albedoUid, list);
@@ -1774,6 +1825,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         // A point cloud has no index buffer by construction, so "no indices"
         // is only a reason to skip when the geometry claimed to be triangles.
         const isPoints = geom.mode === 'POINTS';
+        const isLines = geom.mode === 'LINES';
         if ((!geom.indices && !isPoints) || !geom.attributes.POSITION) { geomI++; continue; }
 
         const map = (perGeomMaps && perGeomMaps[geomI]) || textureMap;
@@ -1790,7 +1842,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             ('Material_' + geomI);
         const matIdx = materialIndexFor(map, matName, geom.uvUnits);
 
-        const primitive = { attributes: {}, material: matIdx, mode: isPoints ? 0 : 4 };
+        const primitive = { attributes: {}, material: matIdx, mode: isPoints ? 0 : isLines ? 1 : 4 };
 
         // Indices
         if (!isPoints) {
@@ -1820,6 +1872,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         // (a point cloud has no UVs and no textures, so there is nothing to bind)
         if (
             !isPoints &&
+            !isLines &&
             !primitive.attributes.TEXCOORD_0 &&
             map &&
             (map.albedo || map.normal || map.metalness)
@@ -2161,13 +2214,32 @@ function resolveRefs(obj, uidMap) {
     return obj;
 }
 
+/**
+ * Is this geometry the viewer's own wireframe overlay?
+ *
+ * Sketchfab draws one for every geometry, authored or not, and it is always
+ * LINES -- so "has a LINES primitive" used to be the test. That also condemns
+ * genuine line geometry, which is equally LINES and equally common in the one
+ * place it matters: a model authored as edges has nothing else in it.
+ *
+ * The overlay keeps its indices in model_file_wireframe.binz while real
+ * geometry indexes out of model_file.binz, and that survives the distinction
+ * being invisible everywhere else. An overlay with no index array at all is
+ * still an overlay; a LINES set indexing real geometry is not.
+ */
 function isWireframeGeom(geom) {
     if (!geom) return false;
     const prims = geom.PrimitiveSetList || [];
-    return prims.some((p) => {
+    let sawLines = false;
+    for (const p of prims) {
         const dt = Object.values(p)[0];
-        return dt && dt.Mode === 'LINES';
-    });
+        if (!dt || dt.Mode !== 'LINES') continue;
+        sawLines = true;
+        const arr = dt.Indices && dt.Indices.Array;
+        const def = arr && Object.values(arr)[0];
+        if (!def || !def.File || !def.File.includes('wireframe')) return false;
+    }
+    return sawLines;
 }
 
 /**

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -967,6 +967,12 @@ function buildTextureMaps(geometries, textureList, textureFiles, viewerMaterials
                 opacityType: spec.opacityType,
                 transmission: !!spec.transmission,
                 opacityAsAlbedo: usedOpacityAsAlbedo,
+                clearCoat: spec.clearCoat
+                    ? { ...spec.clearCoat, texture: resolveUidToBase(spec.clearCoat.textureUid, list) }
+                    : null,
+                sheen: spec.sheen
+                    ? { ...spec.sheen, texture: resolveUidToBase(spec.sheen.textureUid, list) }
+                    : null,
                 via: found.via,
             };
             // Only name-fallback when the viewer pointed at a uid we failed to resolve.
@@ -1265,6 +1271,39 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             } else {
                 material.alphaMode = 'OPAQUE';
             }
+
+            /**
+             * Clearcoat and sheen ride along as glTF extensions. Sketchfab
+             * declares both channels on every material, so these are only
+             * populated when the viewer had them switched on -- see
+             * parseViewerMaterials.
+             */
+            if (map.clearCoat) {
+                const ext = { clearcoatFactor: map.clearCoat.factor };
+                if (typeof map.clearCoat.roughness === 'number') {
+                    ext.clearcoatRoughnessFactor = map.clearCoat.roughness;
+                }
+                if (map.clearCoat.texture) {
+                    const idx = addTexture(map.clearCoat.texture);
+                    if (idx >= 0) ext.clearcoatTexture = { index: idx, texCoord: 0 };
+                }
+                material.extensions = material.extensions || {};
+                material.extensions.KHR_materials_clearcoat = ext;
+                usedExtensions.add('KHR_materials_clearcoat');
+            }
+            if (map.sheen) {
+                const ext = { sheenColorFactor: map.sheen.colorFactor.slice(0, 3) };
+                if (typeof map.sheen.roughness === 'number') {
+                    ext.sheenRoughnessFactor = map.sheen.roughness;
+                }
+                if (map.sheen.texture) {
+                    const idx = addTexture(map.sheen.texture);
+                    if (idx >= 0) ext.sheenColorTexture = { index: idx, texCoord: 0 };
+                }
+                material.extensions = material.extensions || {};
+                material.extensions.KHR_materials_sheen = ext;
+                usedExtensions.add('KHR_materials_sheen');
+            }
         }
 
         return material;
@@ -1287,6 +1326,12 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 'al:' + (map.alpha || ''),
                 'oe:' + (map.opacityEnable ? 1 : 0),
                 'ot:' + (map.opacityType || ''),
+                'cc:' + (map.clearCoat
+                    ? [map.clearCoat.factor, map.clearCoat.roughness, map.clearCoat.texture || ''].join(',')
+                    : ''),
+                'sh:' + (map.sheen
+                    ? [map.sheen.colorFactor.join(','), map.sheen.roughness, map.sheen.texture || ''].join(',')
+                    : ''),
               ].join('|')
             : '__default__';
         if (matCache[key] !== undefined) return matCache[key];

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -302,6 +302,30 @@ function readBufferArray(binData, vb, typeName) {
  * transform, but the caller is told so it can say so out loud rather than
  * quietly shipping the wrong placement.
  */
+/**
+ * Does a Color attribute actually vary from vertex to vertex?
+ *
+ * Sketchfab attaches a Color attribute to most geometries whether or not the
+ * author painted one, and when it is unpainted every vertex carries the same
+ * engine tint. Blender multiplies baseColorTexture by COLOR_0, so exporting a
+ * constant tint makes a textured model look untextured, transparent or simply
+ * wrong -- which is why colour used to be dropped outright.
+ *
+ * Dropping it outright also loses genuine vertex colour, and a mesh painted
+ * per-vertex has no other record of it. Constant-vs-varying is the difference
+ * between the two cases, and it is directly measurable.
+ */
+function colorVaries(data, itemSize) {
+    const stride = itemSize || 4;
+    if (!data || data.length < stride * 2) return false;
+    for (let i = stride; i < data.length; i += stride) {
+        for (let c = 0; c < stride; c++) {
+            if (data[i + c] !== data[c]) return true;
+        }
+    }
+    return false;
+}
+
 export function khrTextureTransform(t) {
     const scale = t.scale || [1, 1];
     const offset = t.offset || [0, 0];
@@ -543,11 +567,15 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, plac
             // untextured / transparent / wrong. True vertex-color meshes are rare
             // on Sketchfab viewer data.
             //
-            // A point cloud is the exception, and not a marginal one: it has no
-            // triangles, no UVs and no textures, so per-vertex colour is the
-            // only surface information in the file. Dropping it leaves a grey
-            // blob.
-            if (result.mode === 'POINTS') {
+            // The tint is constant by definition, so variation is the thing
+            // that separates it from real authored vertex colour -- a far
+            // better discriminator than the primitive mode alone, and it costs
+            // one pass over an attribute already in memory.
+            //
+            // A point cloud is kept regardless: it has no triangles, no UVs and
+            // no textures, so colour is the only surface information in the
+            // file, and a single-colour cloud is still the author's intent.
+            if (result.mode === 'POINTS' || colorVaries(data, itemSize)) {
                 const isFloat = data instanceof Float32Array;
                 result.attributes.COLOR_0 = {
                     data,

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1150,6 +1150,31 @@ function buildTextureMaps(geometries, textureList, textureFiles, viewerMaterials
                 })(),
                 via: found.via,
             };
+            /**
+             * Drop wrap and transform records for roles that resolved to no
+             * texture. They cannot affect the emitted material, but they are
+             * part of its cache key, so leaving them in splits materials that
+             * are byte-for-byte identical.
+             */
+            const hasTexture = {
+                albedo: !!map.albedo,
+                normal: !!map.normal,
+                metalness: !!map.metalness,
+                emissive: !!map.emissive,
+                occlusion: !!map.occlusion,
+                clearCoat: !!(map.clearCoat && (map.clearCoat.texture || map.clearCoat.normalTexture)),
+                sheen: !!(map.sheen && map.sheen.texture),
+            };
+            for (const field of ['wraps', 'uvTransforms']) {
+                if (!map[field]) continue;
+                for (const role of Object.keys(map[field])) {
+                    if (!hasTexture[role] || map[field][role] === undefined) {
+                        delete map[field][role];
+                    }
+                }
+                if (!Object.keys(map[field]).length) map[field] = null;
+            }
+
             // Only name-fallback when the viewer pointed at a uid we failed to resolve.
             // Hair_03 / untextured shells have albedoUid=null — do not steal Hair_D.
             if (!map.albedo && spec.albedoUid) {

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -13,7 +13,11 @@ import {
     dequantize,
     decodeSpherical,
 } from './osg-codec.js';
-import { collectSkeletons } from './skin.js';
+import {
+    collectSkeletons,
+    collectAnimations,
+    decodeChannelCurve,
+} from './skin.js';
 
 // --- Browser helpers (Uint8Array instead of Node Buffer) ---
 function concatBytes(chunks) {
@@ -988,7 +992,8 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         textures: [],
         images: [],
         samplers: [],
-        skins: []
+        skins: [],
+        animations: []
     };
     // Extensions are only declared when a material actually emits one.
     const usedExtensions = new Set();
@@ -1434,6 +1439,54 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         }
     }
 
+    // Curves reuse time accessors aggressively: every bone in a Sketchfab clip
+    // is usually keyed on the same timeline, so this collapses thousands of
+    // identical inputs into a handful.
+    const timeAccessors = [];
+    function addTimeAccessor(times) {
+        for (const entry of timeAccessors) {
+            if (entry.data.length !== times.length) continue;
+            let same = true;
+            for (let i = 0; i < times.length; i++) {
+                if (entry.data[i] !== times[i]) { same = false; break; }
+            }
+            if (same) return entry.accessor;
+        }
+        // Animation inputs must carry min/max, so they keep theirs.
+        const accessor = addAccessor(times, 'SCALAR', 5126, times.length, 1, false, {
+            noStride: true,
+        });
+        timeAccessors.push({ data: times, accessor });
+        return accessor;
+    }
+
+    for (const anim of options.animationCurves || []) {
+        const samplers = [];
+        const channels = [];
+        for (const curve of anim.curves) {
+            const nodeIdx = boneNodeIndex.get(curve.target);
+            if (nodeIdx === undefined) continue;
+            const input = addTimeAccessor(curve.times);
+            const output = addAccessor(
+                curve.values,
+                `VEC${curve.itemSize}`,
+                5126,
+                curve.times.length,
+                curve.itemSize,
+                false,
+                { noStride: true, noMinMax: true }
+            );
+            samplers.push({ input, output, interpolation: 'LINEAR' });
+            channels.push({
+                sampler: samplers.length - 1,
+                target: { node: nodeIdx, path: curve.path },
+            });
+        }
+        if (channels.length) {
+            gltf.animations.push({ name: anim.name || 'Animation', samplers, channels });
+        }
+    }
+
     if (meshNodes.length) {
         // Vertices carry the axis fix already; the parent keeps the official name.
         const root = gltf.nodes.length;
@@ -1454,6 +1507,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
     }
 
     if (!gltf.skins.length) delete gltf.skins;
+    if (!gltf.animations.length) delete gltf.animations;
 
     // Drop empty optional arrays (some strict validators dislike empty textures[])
     if (!gltf.images.length) {
@@ -1793,11 +1847,74 @@ export async function flipNormalMapY(bytes) {
   }
 }
 
+/** Identify an animation payload by its uid, however the caller named it. */
+function animBinKey(name) {
+  return String(name || '')
+    .split('/')
+    .pop()
+    .replace(/\.gz$/i, '')
+    .replace(/\.bin$/i, '')
+    .toLowerCase();
+}
+
+function channelFileName(channel) {
+  const key = channel && channel.KeyFrames && channel.KeyFrames.Key;
+  if (!key || !key.Array) return '';
+  const type = Object.keys(key.Array)[0];
+  return (key.Array[type] && key.Array[type].File) || '';
+}
+
+/**
+ * Decode every animation channel into glTF-ready curves.
+ *
+ * Curves live in a per-animation payload fetched separately from the mesh
+ * bins, so a model can be rigged (skin only) without them.
+ *
+ * @param {object} osgjs
+ * @param {object|null} animationBins  name -> decompressed bytes
+ */
+function buildAnimationCurves(osgjs, animationBins) {
+  const entries = animationBins ? Object.entries(animationBins) : [];
+  if (!entries.length) return [];
+  const animations = collectAnimations(osgjs);
+  if (!animations.length) return [];
+
+  const buffers = new Map();
+  for (const [name, data] of entries) {
+    if (!data) continue;
+    buffers.set(animBinKey(name), asArrayBuffer(data));
+  }
+  const only = buffers.size === 1 ? [...buffers.values()][0] : null;
+
+  const out = [];
+  for (const anim of animations) {
+    const curves = [];
+    let failed = 0;
+    for (const entry of anim.Channels || []) {
+      const type = Object.keys(entry)[0];
+      const channel = entry[type];
+      const bin = buffers.get(animBinKey(channelFileName(channel))) || only;
+      if (!bin) continue;
+      try {
+        const curve = decodeChannelCurve(bin, type, channel);
+        if (curve) curves.push(curve);
+      } catch (e) {
+        failed++;
+      }
+    }
+    if (failed) {
+      console.warn(`  Warning: ${failed} animation channel(s) failed to decode`);
+    }
+    if (curves.length) out.push({ name: anim.Name || 'Animation', curves });
+  }
+  return out;
+}
+
 /**
  * Convert Sketchfab osgjs + bins (+ optional textures) to GLB (+ optional external glTF).
  * @param {Map|object|null} viewerMaterials - from parseViewerMaterials(info)
  */
-export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, viewerMaterials = null) {
+export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, viewerMaterials = null, animationBins = null) {
   const poly = polyBin instanceof Uint8Array
     ? polyBin.buffer.slice(polyBin.byteOffset, polyBin.byteOffset + polyBin.byteLength)
     : polyBin;
@@ -1810,6 +1927,9 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
   const axis = axisRotationFor(osgjs);
   const geometries = collectGeometries(osgjs, poly, wire, axis.matrix);
   const skeletons = collectSkeletons(osgjs, axis.node);
+  const animationCurves = skeletons.skeletons.length
+    ? buildAnimationCurves(osgjs, animationBins)
+    : [];
   if (!geometries.length) {
     throw new Error(
       'No triangle geometries found in osgjs (checked osg.Geometry, RigGeometry.SourceGeometry, MorphGeometry)'
@@ -1934,6 +2054,7 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
   // 1) Embedded GLB
   const embedded = buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, {
     skeletons,
+    animationCurves,
     axisRotation: axis.matrix,
     externalTextures: false,
   });
@@ -1947,6 +2068,7 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
   // 2) External glTF
   const external = buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, {
     skeletons,
+    animationCurves,
     axisRotation: axis.matrix,
     externalTextures: true,
   });
@@ -1983,6 +2105,11 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
       skeletons: skeletons.skeletons.length,
       bones: boneCount,
       skins: (embedded.json.skins || []).length,
+      animations: (embedded.json.animations || []).length,
+      channels: (embedded.json.animations || []).reduce(
+        (n, a) => n + a.channels.length,
+        0
+      ),
     },
     gltfExternal: {
       jsonText,
@@ -2001,6 +2128,13 @@ export async function convertOsgjsToGlbFromFiles(fileMap, viewerMaterials = null
   const poly = fileMap['model_file.bin'];
   if (!poly) throw new Error('model_file.bin missing');
   const wire = fileMap['model_file_wireframe.bin'] || null;
+  const animationBins = {};
+  for (const [name, data] of Object.entries(fileMap)) {
+    if (!(data instanceof Uint8Array)) continue;
+    if (/(^|\/)animations\//i.test(name) || /\.bin\.gz$/i.test(name)) {
+      animationBins[name] = data;
+    }
+  }
   const textures = [];
   if (Array.isArray(textureList)) {
     for (const t of textureList) {
@@ -2013,5 +2147,5 @@ export async function convertOsgjsToGlbFromFiles(fileMap, viewerMaterials = null
       }
     }
   }
-  return convertOsgjsToGlb(osgjs, poly, wire, textures, viewerMaterials);
+  return convertOsgjsToGlb(osgjs, poly, wire, textures, viewerMaterials, animationBins);
 }

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -253,6 +253,45 @@ function readBufferArray(binData, vb, typeName) {
     return new TypedArr(binData, offset, size * itemSize);
 }
 
+/**
+ * Quantization box for one UV set.
+ *
+ * Sketchfab names UV attributes by texture unit -- TexCoord1, TexCoord3,
+ * TexCoord12 -- and writes a matching uv_<unit>_* metadata block. It emits
+ * bbl/h for the first unit only; later units carry uv_<unit>_bits and
+ * uv_<unit>_mode and nothing else, because they are the same base UV map
+ * duplicated once per texture unit and share its box.
+ *
+ * Reading each unit's own box and giving up when it is absent leaves those
+ * sets un-dequantized: raw 14-bit integers, ~8191x too large. Nothing
+ * downstream catches it -- the file still validates and the first UV set
+ * still looks right -- so the fallback matters more than its size suggests.
+ */
+export function uvQuantBox(meta, uvSuffix) {
+    const own = `uv_${uvSuffix}_`;
+    if (meta[own + 'bbl_x'] !== undefined) {
+        return {
+            bbl: [meta[own + 'bbl_x'], meta[own + 'bbl_y']],
+            h: [meta[own + 'h_x'], meta[own + 'h_y']],
+        };
+    }
+    // Lowest-numbered unit that carries a box. Sketchfab always writes one for
+    // the first set in use, and the later sets are copies of it.
+    let donor = null;
+    for (const key of Object.keys(meta)) {
+        const m = /^uv_(\d+)_bbl_x$/.exec(key);
+        if (!m) continue;
+        const n = Number(m[1]);
+        if (donor === null || n < donor) donor = n;
+    }
+    if (donor === null) return null;
+    const p = `uv_${donor}_`;
+    return {
+        bbl: [meta[p + 'bbl_x'], meta[p + 'bbl_y']],
+        h: [meta[p + 'h_x'], meta[p + 'h_y']],
+    };
+}
+
 function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, placement, opts = {}) {
     const userData = sharedState || {};
     const result = { name: geom.Name || 'unnamed', attributes: {}, indices: null, mode: 'TRIANGLES', material: null };
@@ -387,18 +426,16 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, plac
             }
         } else if (attrName.startsWith('TexCoord')) {
             const uvSuffix = attrName.replace('TexCoord', '');
-            const prefix = `uv_${uvSuffix}_`;
             const uvMode = meta[`uv_${uvSuffix}_mode`] !== undefined ? meta[`uv_${uvSuffix}_mode`] : (meta.vertex_mode || 0);
             // Apply parallelogram prediction
             if ((uvMode & 2) && result.stripIndices) {
                 parallelogramPredict(data, itemSize, result.stripIndices);
             }
             // Dequantize
-            if (meta[prefix + 'bbl_x'] !== undefined && ((attrFlags & 4) || (uvMode & 1))) {
-                const bbl = [meta[prefix + 'bbl_x'], meta[prefix + 'bbl_y']];
-                const h = [meta[prefix + 'h_x'], meta[prefix + 'h_y']];
+            const box = uvQuantBox(meta, uvSuffix);
+            if (box && ((attrFlags & 4) || (uvMode & 1))) {
                 const floats = new Float32Array(data.length);
-                dequantize(data, floats, bbl, h, itemSize);
+                dequantize(data, floats, box.bbl, box.h, itemSize);
                 data = floats;
             } else if (!(data instanceof Float32Array)) {
                 data = new Float32Array(data);

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1,12 +1,19 @@
 import { decodePngRgba, encodePngRgba } from './descramble.js';
 import { isPackedOrmName } from './orm.js';
-import { axisRotationFor, isIdentityMat3 } from './osg-scene.js';
+import {
+    axisRotationFor,
+    isIdentityMat3,
+    mat3Transpose,
+    mat4FromMat3,
+    ZUP_TO_YUP_MAT3,
+} from './osg-scene.js';
 import {
     decodeVarint,
     deltaDecodeInPlace,
     dequantize,
     decodeSpherical,
 } from './osg-codec.js';
+import { collectSkeletons } from './skin.js';
 
 // --- Browser helpers (Uint8Array instead of Node Buffer) ---
 function concatBytes(chunks) {
@@ -980,7 +987,8 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         materials: [],
         textures: [],
         images: [],
-        samplers: []
+        samplers: [],
+        skins: []
     };
     // Extensions are only declared when a material actually emits one.
     const usedExtensions = new Set();
@@ -988,8 +996,8 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
     const binChunks = [];
     let byteOffset = 0;
 
-    function addAccessor(data, type, componentType, count, itemSize, normalized) {
-        const typeMap = { 1: 'SCALAR', 2: 'VEC2', 3: 'VEC3', 4: 'VEC4' };
+    function addAccessor(data, type, componentType, count, itemSize, normalized, opts = {}) {
+        const typeMap = { 1: 'SCALAR', 2: 'VEC2', 3: 'VEC3', 4: 'VEC4', 16: 'MAT4' };
         let buf;
         // Prefer view over copy when already the right TypedArray
         if (componentType === 5126) {
@@ -1012,16 +1020,20 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         const isIndex = type === 'SCALAR' && (componentType === 5125 || componentType === 5123);
         gltf.bufferViews.push({
             buffer: 0, byteOffset, byteLength: bytes.length,
-            ...(!isIndex && itemSize > 1 ? { byteStride: itemSize * buf.BYTES_PER_ELEMENT } : {})
+            ...(!isIndex && !opts.noStride && itemSize > 1
+                ? { byteStride: itemSize * buf.BYTES_PER_ELEMENT }
+                : {})
         });
 
         const min = [], max = [];
-        for (let j = 0; j < itemSize; j++) { min.push(Infinity); max.push(-Infinity); }
-        for (let i = 0; i < count; i++) {
-            for (let j = 0; j < itemSize; j++) {
-                const v = buf[i * itemSize + j];
-                if (v < min[j]) min[j] = v;
-                if (v > max[j]) max[j] = v;
+        if (!opts.noMinMax) {
+            for (let j = 0; j < itemSize; j++) { min.push(Infinity); max.push(-Infinity); }
+            for (let i = 0; i < count; i++) {
+                for (let j = 0; j < itemSize; j++) {
+                    const v = buf[i * itemSize + j];
+                    if (v < min[j]) min[j] = v;
+                    if (v > max[j]) max[j] = v;
+                }
             }
         }
 
@@ -1029,7 +1041,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         gltf.accessors.push({
             bufferView: bvIdx, byteOffset: 0, componentType,
             count, type: typeMap[itemSize] || 'SCALAR',
-            min, max,
+            ...(opts.noMinMax ? {} : { min, max }),
             ...(normalized ? { normalized: true } : {})
         });
 
@@ -1226,6 +1238,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
     if (!textureMap) textureMap = null;
 
     const meshNodes = [];
+    const skinnedMeshNodes = [];
     let geomI = 0;
     for (const geom of geometries) {
         if (!geom.indices || !geom.attributes.POSITION) { geomI++; continue; }
@@ -1291,15 +1304,142 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         const nodeIdx = gltf.nodes.length;
         gltf.nodes.push({ name: meshName, mesh: meshIdx });
         meshNodes.push(nodeIdx);
+        if (geom.boneMap) skinnedMeshNodes.push([nodeIdx, geom]);
         geomI++;
     }
 
+    // --- Skeletons and skins ---
+    // Joints are emitted as siblings of the meshes rather than as their
+    // parents: glTF forbids a skinned mesh's own node from being a joint, and
+    // ignores that node's transform anyway — a skinned vertex is placed purely
+    // by its joints.
+    const IDENTITY_MAT4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+    // processGeometry bakes the axis fix into the vertices, so the rig has to
+    // be turned with them. It rides on a wrapper above each root bone rather
+    // than on the bone itself, so that the bone's own transform stays free.
+    // Vertices arrive already rotated, so the inverse bind matrices undo it
+    // before binding.
+    const axisRotation = options.axisRotation || ZUP_TO_YUP_MAT3;
+    const AXIS_MAT4 = mat4FromMat3(axisRotation);
+    const AXIS_INVERSE_MAT4 = mat4FromMat3(mat3Transpose(axisRotation));
+
+    /** Column-major 4x4 product a x b (b applied first). */
+    function mat4Multiply(a, b) {
+        const out = new Float32Array(16);
+        for (let c = 0; c < 4; c++) {
+            for (let r = 0; r < 4; r++) {
+                let sum = 0;
+                for (let k = 0; k < 4; k++) sum += a[k * 4 + r] * b[c * 4 + k];
+                out[c * 4 + r] = sum;
+            }
+        }
+        return out;
+    }
+
+    const skeletonData = options.skeletons || null;
+    const boneNodeIndex = new Map();
+    const rigRootNodes = [];
+    const rigRootBySkeleton = new Map();
+
+    function emitBoneNode(bone) {
+        const nodeIdx = gltf.nodes.length;
+        const node = { name: bone.name || 'Bone' };
+        gltf.nodes.push(node);
+        if (bone.name) boneNodeIndex.set(bone.name, nodeIdx);
+        if (bone.trs) {
+            node.translation = Array.from(bone.trs.translation);
+            node.rotation = Array.from(bone.trs.rotation);
+            node.scale = Array.from(bone.trs.scale);
+        }
+        const kids = [];
+        for (const child of bone.children) kids.push(emitBoneNode(child));
+        if (kids.length) node.children = kids;
+        return nodeIdx;
+    }
+
+    if (skeletonData && skeletonData.skeletons) {
+        for (const skeleton of skeletonData.skeletons) {
+            if (!skeleton.roots.length) continue;
+            const wrapperIdx = gltf.nodes.length;
+            const wrapper = {
+                name: (skeleton.json && skeleton.json.Name) || 'Skeleton',
+                // Axis fix, then the character's own placement, which the
+                // flattened mesh path bakes into its vertices.
+                matrix: Array.from(
+                    mat4Multiply(AXIS_MAT4, skeleton.worldMatrix || IDENTITY_MAT4)
+                ),
+                children: [],
+            };
+            gltf.nodes.push(wrapper);
+            for (const rootBone of skeleton.roots) wrapper.children.push(emitBoneNode(rootBone));
+            rigRootBySkeleton.set(skeleton, wrapperIdx);
+            rigRootNodes.push(wrapperIdx);
+        }
+    }
+
+    /** Skin for one rigged mesh, ordered by its own dense BoneMap. */
+    function skinForGeometry(geom) {
+        if (!geom.boneMap || !boneNodeIndex.size) return -1;
+        const entries = Object.entries(geom.boneMap);
+        let maxIdx = -1;
+        for (const [, i] of entries) if (i > maxIdx) maxIdx = i;
+        if (maxIdx < 0) return -1;
+
+        const joints = new Array(maxIdx + 1).fill(-1);
+        const ibm = new Float32Array((maxIdx + 1) * 16);
+        let skeletonRoot = -1;
+        for (const [name, i] of entries) {
+            const nodeIdx = boneNodeIndex.get(name);
+            if (nodeIdx === undefined || i < 0 || i > maxIdx) continue;
+            joints[i] = nodeIdx;
+            const bone = skeletonData.boneByName.get(name);
+            const inv = bone && bone.invBind;
+            ibm.set(
+                inv && inv.length >= 16
+                    ? mat4Multiply(inv, AXIS_INVERSE_MAT4)
+                    : IDENTITY_MAT4,
+                i * 16
+            );
+            if (skeletonRoot < 0 && bone && rigRootBySkeleton.has(bone.skeleton)) {
+                skeletonRoot = rigRootBySkeleton.get(bone.skeleton);
+            }
+        }
+        // A hole in the map would be invalid glTF; park it on the root.
+        for (let i = 0; i < joints.length; i++) {
+            if (joints[i] >= 0) continue;
+            joints[i] = skeletonRoot >= 0 ? skeletonRoot : 0;
+            ibm.set(IDENTITY_MAT4, i * 16);
+        }
+        const acc = addAccessor(ibm, 'MAT4', 5126, joints.length, 16, false, {
+            noStride: true,
+            noMinMax: true,
+        });
+        gltf.skins.push({
+            joints,
+            inverseBindMatrices: acc,
+            ...(skeletonRoot >= 0 ? { skeleton: skeletonRoot } : {}),
+        });
+        return gltf.skins.length - 1;
+    }
+
+    for (const [nodeIdx, geom] of skinnedMeshNodes) {
+        const skinIdx = skinForGeometry(geom);
+        if (skinIdx >= 0) gltf.nodes[nodeIdx].skin = skinIdx;
+        else {
+            // No usable skin: drop the attributes so importers do not see a
+            // JOINTS_0 with nothing to bind it to.
+            const prim = gltf.meshes[gltf.nodes[nodeIdx].mesh].primitives[0];
+            delete prim.attributes.JOINTS_0;
+            delete prim.attributes.WEIGHTS_0;
+        }
+    }
+
     if (meshNodes.length) {
-        // Vertices are already Y-up. Identity parent keeps the official name.
+        // Vertices carry the axis fix already; the parent keeps the official name.
         const root = gltf.nodes.length;
         gltf.nodes.push({
             name: 'Sketchfab_model',
-            children: meshNodes.slice(),
+            children: meshNodes.concat(rigRootNodes),
         });
         gltf.scenes[0].nodes = [root];
     } else {
@@ -1312,6 +1452,8 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
     if (!gltf.images.length && textureFiles && textureMap && textureMap.albedo) {
         // rebuild default material with texture attempt already done — nothing more
     }
+
+    if (!gltf.skins.length) delete gltf.skins;
 
     // Drop empty optional arrays (some strict validators dislike empty textures[])
     if (!gltf.images.length) {
@@ -1368,6 +1510,59 @@ function isWireframeGeom(geom) {
     });
 }
 
+/**
+ * Per-vertex skinning attributes from a RigGeometry.
+ *
+ * Bones/Weights hang off the rig wrapper rather than its SourceGeometry, and
+ * the bone indices address the rig's own BoneMap, so a skin built from that
+ * map can use them verbatim. glTF wants sets of four, so narrower rigs are
+ * zero-padded.
+ */
+function readRigAttributes(rig, polyBin, vertexCount) {
+    const vaList = (rig && rig.VertexAttributeList) || {};
+    if (!vaList.Bones || !vaList.Weights || !rig.BoneMap) return null;
+
+    function read(attr) {
+        const arrInfo = attr.Array;
+        const arrType = Object.keys(arrInfo)[0];
+        const arrDef = arrInfo[arrType];
+        const itemSize = attr.ItemSize || 4;
+        const data = readBufferArray(
+            asArrayBuffer(polyBin),
+            { ...arrDef, ItemSize: itemSize },
+            arrType
+        );
+        return { data, count: arrDef.Size, itemSize };
+    }
+
+    let bones;
+    let weights;
+    try {
+        bones = read(vaList.Bones);
+        weights = read(vaList.Weights);
+    } catch (_) {
+        return null;
+    }
+    if (bones.count !== vertexCount || weights.count !== vertexCount) return null;
+
+    const joints = new Uint16Array(vertexCount * 4);
+    const wts = new Float32Array(vertexCount * 4);
+    const boneCount = Object.keys(rig.BoneMap).length;
+    const n = Math.min(4, bones.itemSize);
+    for (let i = 0; i < vertexCount; i++) {
+        for (let k = 0; k < n; k++) {
+            const j = bones.data[i * bones.itemSize + k];
+            // A stray index would silently bind to the wrong bone; drop it.
+            joints[i * 4 + k] = j < boneCount ? j : 0;
+            wts[i * 4 + k] = weights.data[i * weights.itemSize + k];
+        }
+    }
+    return {
+        JOINTS_0: { data: joints, itemSize: 4, count: vertexCount, componentType: 5123 },
+        WEIGHTS_0: { data: wts, itemSize: 4, count: vertexCount, componentType: 5126 },
+    };
+}
+
 /** Unwrap SourceGeometry / Morph / plain Geometry dict into osg.Geometry payload. */
 function extractMeshGeometry(wrapper) {
     if (!wrapper || typeof wrapper !== 'object') return null;
@@ -1398,7 +1593,7 @@ function collectGeometries(node, polyBin, wireBin, axisRotation) {
     const sharedState = { expectedState: [0] };
     const stats = { rig: 0, geom: 0, morph: 0, wire: 0, skip: 0, errors: [] };
 
-    function acceptGeometry(geom, label) {
+    function acceptGeometry(geom, label, rig) {
         if (!geom) return;
         if (isWireframeGeom(geom)) {
             stats.wire++;
@@ -1422,6 +1617,18 @@ function collectGeometries(node, polyBin, wireBin, axisRotation) {
                 for (const k of tcKeys) {
                     result.attributes[`TEXCOORD_${tcIdx++}`] = result.attributes[k];
                     delete result.attributes[k];
+                }
+                if (rig) {
+                    const skinAttrs = readRigAttributes(
+                        rig,
+                        polyBin,
+                        result.attributes.POSITION.count
+                    );
+                    if (skinAttrs) {
+                        result.attributes.JOINTS_0 = skinAttrs.JOINTS_0;
+                        result.attributes.WEIGHTS_0 = skinAttrs.WEIGHTS_0;
+                        result.boneMap = rig.BoneMap;
+                    }
                 }
                 results.push(result);
             } else {
@@ -1452,7 +1659,7 @@ function collectGeometries(node, polyBin, wireBin, axisRotation) {
             const rig = obj['osgAnimation.RigGeometry'] || obj['osg.RigGeometry'];
             stats.rig++;
             const mesh = extractMeshGeometry(rig);
-            acceptGeometry(mesh, 'RigGeometry');
+            acceptGeometry(mesh, 'RigGeometry', rig);
             // Walk other fields except SourceGeometry (already handled)
             for (const [k, v] of Object.entries(rig)) {
                 if (k === 'SourceGeometry') continue;
@@ -1602,6 +1809,7 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
   // One axis decision for the whole model, read from the scene graph.
   const axis = axisRotationFor(osgjs);
   const geometries = collectGeometries(osgjs, poly, wire, axis.matrix);
+  const skeletons = collectSkeletons(osgjs, axis.node);
   if (!geometries.length) {
     throw new Error(
       'No triangle geometries found in osgjs (checked osg.Geometry, RigGeometry.SourceGeometry, MorphGeometry)'
@@ -1725,6 +1933,8 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
 
   // 1) Embedded GLB
   const embedded = buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, {
+    skeletons,
+    axisRotation: axis.matrix,
     externalTextures: false,
   });
   const glb = packGlb(embedded.json, embedded.bin);
@@ -1736,6 +1946,8 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
 
   // 2) External glTF
   const external = buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, {
+    skeletons,
+    axisRotation: axis.matrix,
     externalTextures: true,
   });
   external.json.buffers = [
@@ -1761,11 +1973,17 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
     }
   }
 
+  const boneCount = skeletons.skeletons.reduce((n, sk) => n + sk.bones.length, 0);
   return {
     glb,
     geometryCount: meshCount || geometries.length,
     json: embedded.json,
     textureEmbedCount,
+    rig: {
+      skeletons: skeletons.skeletons.length,
+      bones: boneCount,
+      skins: (embedded.json.skins || []).length,
+    },
     gltfExternal: {
       jsonText,
       bin: external.bin instanceof Uint8Array ? external.bin : new Uint8Array(external.bin),

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1,6 +1,12 @@
 import { decodePngRgba, encodePngRgba } from './descramble.js';
 import { isPackedOrmName } from './orm.js';
 import { axisRotationFor, isIdentityMat3 } from './osg-scene.js';
+import {
+    decodeVarint,
+    deltaDecodeInPlace,
+    dequantize,
+    decodeSpherical,
+} from './osg-codec.js';
 
 // --- Browser helpers (Uint8Array instead of Node Buffer) ---
 function concatBytes(chunks) {
@@ -48,81 +54,6 @@ function applyAxisRotation(result, m) {
 }
 
 // --- Sketchfab binary decoders (extracted from viewer JS) ---
-
-function decodeVarint(bytes, count, typeName) {
-    const signed = typeName[0] !== 'U';
-    const result = signed ? new Int32Array(count) : new Uint32Array(count);
-    let a = 0, o = 0;
-    while (a < count) {
-        let s = 0, l = 0;
-        do { s |= (bytes[o] & 127) << l; l += 7; } while ((bytes[o++] & 128) !== 0);
-        result[a++] = s;
-    }
-    if (signed) {
-        for (let u = 0; u < count; u++) {
-            const c = result[u];
-            result[u] = (c >> 1) ^ -(c & 1); // zigzag decode
-        }
-    }
-    return result;
-}
-
-function deltaDecodeInPlace(arr, startIdx) {
-    const start = startIdx || 0;
-    let prev = arr[start];
-    for (let i = start + 1; i < arr.length; i++) {
-        const v = arr[i];
-        prev = arr[i] = prev + (v >> 1 ^ -(v & 1));
-    }
-    return arr;
-}
-
-function dequantize(encoded, output, bbl, h, itemSize) {
-    const count = encoded.length / itemSize;
-    for (let i = 0; i < count; i++) {
-        const base = i * itemSize;
-        for (let j = 0; j < itemSize; j++) {
-            output[base + j] = bbl[j] + encoded[base + j] * h[j];
-        }
-    }
-    return output;
-}
-
-function decodeNormals(encoded, output, itemSize, epsilon, nphi, hasThirdComponent) {
-    epsilon = epsilon || 0.25;
-    nphi = nphi || 720;
-    const PI = 3.14159265359;
-    const cosEps = Math.cos(0.01745329251 * epsilon);
-    const dPhi = PI / (nphi - 1);
-    const dGamma = 1.57079632679 / (nphi - 1);
-    const stride = hasThirdComponent ? 3 : 2;
-    const count = encoded.length / stride;
-
-    for (let i = 0; i < count; i++) {
-        const outIdx = i * itemSize;
-        const inIdx = i * stride;
-        let S = encoded[inIdx];
-        let x = encoded[inIdx + 1];
-
-        if (itemSize === 4 && !hasThirdComponent) {
-            output[outIdx + 3] = (S & 1024) ? -1 : 1;
-            S &= ~1024;
-        }
-
-        const A0 = S * dPhi;
-        const R = Math.cos(A0);
-        const w = Math.sin(A0);
-        const A1 = A0 + dGamma;
-        let E = (cosEps - R * Math.cos(A1)) / Math.max(1e-5, w * Math.sin(A1));
-        if (E > 1) E = 1; else if (E < -1) E = -1;
-        const P = 6.28318530718 * x / Math.ceil(PI / Math.max(1e-5, Math.acos(E)));
-
-        output[outIdx] = w * Math.cos(P);
-        output[outIdx + 1] = w * Math.sin(P);
-        output[outIdx + 2] = R;
-    }
-    return output;
-}
 
 function implicitDecode(encoded, output, startIdx, useExpected) {
     let r = encoded[2]; // expectedIndex
@@ -377,7 +308,7 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation) {
         } else if (attrName === 'Normal') {
             if (attrFlags & 2) {
                 const floats = new Float32Array(count * 3);
-                decodeNormals(data, floats, 3, meta.epsilon, meta.nphi);
+                decodeSpherical(data, floats, 3, meta.epsilon, meta.nphi);
                 result.attributes.NORMAL = { data: floats, itemSize: 3, count };
             } else {
                 result.attributes.NORMAL = { data, itemSize, count };
@@ -385,7 +316,7 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation) {
         } else if (attrName === 'Tangent') {
             if (attrFlags & 32) {
                 const floats = new Float32Array(count * 4);
-                decodeNormals(data, floats, 4, meta.epsilon, meta.nphi);
+                decodeSpherical(data, floats, 4, meta.epsilon, meta.nphi);
                 result.attributes.TANGENT = { data: floats, itemSize: 4, count };
             }
         } else if (attrName.startsWith('TexCoord')) {

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1056,7 +1056,11 @@ function buildTextureMaps(geometries, textureList, textureFiles, viewerMaterials
                 transmission: !!spec.transmission,
                 opacityAsAlbedo: usedOpacityAsAlbedo,
                 clearCoat: spec.clearCoat
-                    ? { ...spec.clearCoat, texture: resolveUidToBase(spec.clearCoat.textureUid, list) }
+                    ? {
+                        ...spec.clearCoat,
+                        texture: resolveUidToBase(spec.clearCoat.textureUid, list),
+                        normalTexture: resolveUidToBase(spec.clearCoat.normalTextureUid, list),
+                      }
                     : null,
                 sheen: spec.sheen
                     ? { ...spec.sheen, texture: resolveUidToBase(spec.sheen.textureUid, list) }
@@ -1391,6 +1395,12 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                     const idx = addTexture(map.clearCoat.texture);
                     if (idx >= 0) ext.clearcoatTexture = { index: idx, texCoord: tc('clearCoat') };
                 }
+                if (map.clearCoat.normalTexture) {
+                    const idx = addTexture(map.clearCoat.normalTexture, {
+                        flipNormalY: !!map.clearCoat.normalFlipY,
+                    });
+                    if (idx >= 0) ext.clearcoatNormalTexture = { index: idx, texCoord: 0 };
+                }
                 material.extensions = material.extensions || {};
                 material.extensions.KHR_materials_clearcoat = ext;
                 usedExtensions.add('KHR_materials_clearcoat');
@@ -1436,7 +1446,13 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 'oe:' + (map.opacityEnable ? 1 : 0),
                 'ot:' + (map.opacityType || ''),
                 'cc:' + (map.clearCoat
-                    ? [map.clearCoat.factor, map.clearCoat.roughness, map.clearCoat.texture || ''].join(',')
+                    ? [
+                        map.clearCoat.factor,
+                        map.clearCoat.roughness,
+                        map.clearCoat.texture || '',
+                        map.clearCoat.normalTexture || '',
+                        map.clearCoat.normalFlipY ? 1 : 0,
+                      ].join(',')
                     : ''),
                 'sh:' + (map.sheen
                     ? [map.sheen.colorFactor.join(','), map.sheen.roughness, map.sheen.texture || ''].join(',')
@@ -2471,6 +2487,9 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
       anySpec = true;
       if (spec.normalFlipY && spec.normalUid) {
         needFlipUids.add(String(spec.normalUid).toLowerCase());
+      }
+      if (spec.clearCoat && spec.clearCoat.normalFlipY && spec.clearCoat.normalTextureUid) {
+        needFlipUids.add(String(spec.clearCoat.normalTextureUid).toLowerCase());
       }
     }
     // If materials say flipY explicitly for some, only flip those; else keep flipAllNormals

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1987,6 +1987,20 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 false,
                 { noStride: true, noMinMax: true }
             );
+            /**
+             * Animation interpolation is always LINEAR, and that is not a shortcut.
+             *
+             * osgjs types every channel by its interpolation -- Vec3LerpChannel,
+             * QuatSlerpChannel, FloatLerpChannel, and the Compressed/Packed variants of
+             * each -- so a stepped clip would arrive as a distinguishable type. None does.
+             * The v2 fixture authored A11_StepAnimation with every keyframe set to
+             * Blender's CONSTANT interpolation; it comes back from Sketchfab as a single
+             * Vec3LerpChannelCompressedPacked. Across r3_01, v3_02 and v3_03 -- 9 clips,
+             * 91 channels -- every one is Lerp or Slerp.
+             *
+             * Sketchfab's importer flattens step keys on the way in, so there is no
+             * stepping left to preserve and writing anything else would be a guess.
+             */
             samplers.push({ input, output, interpolation: 'LINEAR' });
             channels.push({
                 sampler: samplers.length - 1,

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1103,6 +1103,7 @@ function buildTextureMaps(geometries, textureList, textureFiles, viewerMaterials
                 sheen: spec.sheen
                     ? { ...spec.sheen, texture: resolveUidToBase(spec.sheen.textureUid, list) }
                     : null,
+                doubleSided: spec.doubleSided !== false,
                 // Non-identity UV transform per role, for KHR_texture_transform.
                 uvTransforms: (() => {
                     const at = (uid) =>
@@ -1460,7 +1461,9 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         const factors = pbrFactors(map);
         const material = {
             name: name || 'Material',
-            doubleSided: true,
+            // Unculled unless the viewer said otherwise; a map with no
+            // sided-ness information keeps the old permissive default.
+            doubleSided: !map || map.doubleSided !== false,
             pbrMetallicRoughness: {
                 baseColorFactor: baseF.slice(0, 4),
                 metallicFactor: factors.metallicFactor,
@@ -1599,6 +1602,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 'mf:' + (map.metallicFactor != null ? map.metallicFactor : ''),
                 'rf:' + (map.roughnessFactor != null ? map.roughnessFactor : ''),
                 'fy:' + (map.normalFlipY ? 1 : 0),
+                'ds:' + (map.doubleSided === false ? 0 : 1),
                 'al:' + (map.alpha || ''),
                 'oe:' + (map.opacityEnable ? 1 : 0),
                 'ot:' + (map.opacityType || ''),

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -267,6 +267,30 @@ function readBufferArray(binData, vb, typeName) {
  * downstream catches it -- the file still validates and the first UV set
  * still looks right -- so the fallback matters more than its size suggests.
  */
+/**
+ * glTF texCoord index per material role, for one geometry's UV layout.
+ *
+ * The viewer records which *texture unit* a channel samples; the converter
+ * renumbers a mesh's TexCoord attributes to a dense TEXCOORD_0..n. Those two
+ * agree for the overwhelming majority of meshes, which carry a single UV set,
+ * and disagree exactly when a mesh has more than one -- a lightmap bound to
+ * the second set would otherwise be sampled with the first set's coordinates.
+ *
+ * Returns only the roles that need a non-zero index, so a single-UV mesh
+ * yields {} and cannot fragment the material cache.
+ */
+export function texCoordsForGeometry(map, uvUnits) {
+    const out = {};
+    const units = map && map.uvUnits;
+    if (!units || !Array.isArray(uvUnits) || uvUnits.length < 2) return out;
+    for (const [role, unit] of Object.entries(units)) {
+        if (typeof unit !== 'number') continue;
+        const i = uvUnits.indexOf(unit);
+        if (i > 0) out[role] = i;
+    }
+    return out;
+}
+
 export function uvQuantBox(meta, uvSuffix) {
     const own = `uv_${uvSuffix}_`;
     if (meta[own + 'bbl_x'] !== undefined) {
@@ -1010,6 +1034,21 @@ function buildTextureMaps(geometries, textureList, textureFiles, viewerMaterials
                 sheen: spec.sheen
                     ? { ...spec.sheen, texture: resolveUidToBase(spec.sheen.textureUid, list) }
                     : null,
+                // Which texture unit each role samples, so a material bound to
+                // a second UV set can be pointed at the right TEXCOORD_n.
+                uvUnits: (() => {
+                    const at = (uid) =>
+                        uid && spec.texCoordUnits ? spec.texCoordUnits[uid] : undefined;
+                    return {
+                        albedo: at(spec.albedoUid),
+                        normal: at(spec.normalUid),
+                        metalness: at(spec.metalnessUid),
+                        emissive: at(spec.emitUid),
+                        occlusion: at(spec.aoUid),
+                        clearCoat: spec.clearCoat ? at(spec.clearCoat.textureUid) : undefined,
+                        sheen: spec.sheen ? at(spec.sheen.textureUid) : undefined,
+                    };
+                })(),
                 via: found.via,
             };
             // Only name-fallback when the viewer pointed at a uid we failed to resolve.
@@ -1227,7 +1266,8 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
      * Build a glTF PBR material from viewer channel specs.
      * Defaults match Sketchfab lit/PBR: metalness 0, no invented ORM maps.
      */
-    function makeMaterial(name, map) {
+    function makeMaterial(name, map, texCoords = {}) {
+        const tc = (role) => texCoords[role] || 0;
         const baseF = (map && map.baseColorFactor) || [1, 1, 1, 1];
         const factors = pbrFactors(map);
         const material = {
@@ -1247,7 +1287,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             if (map.albedo) {
                 const idx = addTexture(map.albedo);
                 if (idx >= 0) {
-                    material.pbrMetallicRoughness.baseColorTexture = { index: idx, texCoord: 0 };
+                    material.pbrMetallicRoughness.baseColorTexture = { index: idx, texCoord: tc('albedo') };
                 }
             }
             if (map.metalness && factors.bindTexture) {
@@ -1255,25 +1295,25 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 if (idx >= 0) {
                     material.pbrMetallicRoughness.metallicRoughnessTexture = {
                         index: idx,
-                        texCoord: 0,
+                        texCoord: tc('metalness'),
                     };
                 }
             }
             if (map.normal) {
                 // flipY handled when packing texture bytes (see flipNormalMapY)
                 const idx = addTexture(map.normal, { flipNormalY: !!map.normalFlipY });
-                if (idx >= 0) material.normalTexture = { index: idx, texCoord: 0, scale: 1 };
+                if (idx >= 0) material.normalTexture = { index: idx, texCoord: tc('normal'), scale: 1 };
             }
             if (map.emissive) {
                 const idx = addTexture(map.emissive);
                 if (idx >= 0) {
-                    material.emissiveTexture = { index: idx, texCoord: 0 };
+                    material.emissiveTexture = { index: idx, texCoord: tc('emissive') };
                     material.emissiveFactor = [1, 1, 1];
                 }
             }
             if (map.occlusion) {
                 const idx = addTexture(map.occlusion);
-                if (idx >= 0) material.occlusionTexture = { index: idx, texCoord: 0, strength: 1 };
+                if (idx >= 0) material.occlusionTexture = { index: idx, texCoord: tc('occlusion'), strength: 1 };
             }
             // Opacity / cutout from viewer material
             const opType = String(map.opacityType || '');
@@ -1322,7 +1362,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 }
                 if (map.clearCoat.texture) {
                     const idx = addTexture(map.clearCoat.texture);
-                    if (idx >= 0) ext.clearcoatTexture = { index: idx, texCoord: 0 };
+                    if (idx >= 0) ext.clearcoatTexture = { index: idx, texCoord: tc('clearCoat') };
                 }
                 material.extensions = material.extensions || {};
                 material.extensions.KHR_materials_clearcoat = ext;
@@ -1335,7 +1375,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 }
                 if (map.sheen.texture) {
                     const idx = addTexture(map.sheen.texture);
-                    if (idx >= 0) ext.sheenColorTexture = { index: idx, texCoord: 0 };
+                    if (idx >= 0) ext.sheenColorTexture = { index: idx, texCoord: tc('sheen') };
                 }
                 material.extensions = material.extensions || {};
                 material.extensions.KHR_materials_sheen = ext;
@@ -1348,7 +1388,12 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
 
     // Material cache keyed by map signature
     const matCache = Object.create(null);
-    function materialIndexFor(map, geomName) {
+    function materialIndexFor(map, geomName, uvUnits) {
+        // Two geometries can share every texture and still need different
+        // bindings when their UV layouts differ, so the resolved indices are
+        // part of the cache key. They are empty for single-UV meshes, which is
+        // nearly all of them, so the key is unchanged in the common case.
+        const texCoords = texCoordsForGeometry(map, uvUnits);
         const key = map
             ? [
                 'a:' + (map.albedo || ''),
@@ -1369,10 +1414,11 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 'sh:' + (map.sheen
                     ? [map.sheen.colorFactor.join(','), map.sheen.roughness, map.sheen.texture || ''].join(',')
                     : ''),
+                'tc:' + JSON.stringify(texCoords),
               ].join('|')
             : '__default__';
         if (matCache[key] !== undefined) return matCache[key];
-        const mat = makeMaterial(geomName || 'Material', map);
+        const mat = makeMaterial(geomName || 'Material', map, texCoords);
         const idx = gltf.materials.length;
         gltf.materials.push(mat);
         matCache[key] = idx;
@@ -1467,7 +1513,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             geom.materialName ||
             geom.name ||
             ('Material_' + geomI);
-        const matIdx = materialIndexFor(map, matName);
+        const matIdx = materialIndexFor(map, matName, geom.uvUnits);
 
         const primitive = { attributes: {}, material: matIdx, mode: 4 };
 
@@ -2060,9 +2106,16 @@ function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
             if (underAnimated) result.animCtx = animCtx;
             if (result.indices && result.attributes.POSITION) {
                 // Remap _TC_* to continuous TEXCOORD_0, TEXCOORD_1, ...
+                //
+                // Sorted numerically, not lexicographically: the suffix is a
+                // sparse texture unit, so a mesh carrying units 3 and 12 would
+                // otherwise order 12 first and swap the two sets.
                 const tcKeys = Object.keys(result.attributes)
                     .filter((k) => k.startsWith('_TC_'))
-                    .sort();
+                    .sort((a, b) => Number(a.slice(4)) - Number(b.slice(4)));
+                // Unit -> TEXCOORD index is positional, so keeping the units in
+                // emit order is enough for materials to resolve their binding.
+                result.uvUnits = tcKeys.map((k) => Number(k.slice(4)));
                 let tcIdx = 0;
                 for (const k of tcKeys) {
                     result.attributes[`TEXCOORD_${tcIdx++}`] = result.attributes[k];

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1395,6 +1395,13 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
 
     const skeletonData = options.skeletons || null;
     const boneNodeIndex = new Map();
+    /**
+     * Separate from boneNodeIndex on purpose. Skin binding resolves names out
+     * of a RigGeometry's BoneMap and must keep matching bone names exactly;
+     * adding animation aliases to that map risks binding a mesh to the wrong
+     * joint. Animation targets get their own lookup.
+     */
+    const animTargetIndex = new Map();
     const rigRootNodes = [];
     const rigRootBySkeleton = new Map();
 
@@ -1403,6 +1410,10 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         const node = { name: bone.name || 'Bone' };
         gltf.nodes.push(node);
         if (bone.name) boneNodeIndex.set(bone.name, nodeIdx);
+        if (bone.name && !animTargetIndex.has(bone.name)) animTargetIndex.set(bone.name, nodeIdx);
+        if (bone.animName && !animTargetIndex.has(bone.animName)) {
+            animTargetIndex.set(bone.animName, nodeIdx);
+        }
         if (bone.trs) {
             node.translation = Array.from(bone.trs.translation);
             node.rotation = Array.from(bone.trs.rotation);
@@ -1516,7 +1527,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         const samplers = [];
         const channels = [];
         for (const curve of anim.curves) {
-            const nodeIdx = boneNodeIndex.get(curve.target);
+            const nodeIdx = animTargetIndex.get(curve.target);
             if (nodeIdx === undefined) continue;
             const input = addTimeAccessor(curve.times);
             const output = addAccessor(

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -279,6 +279,44 @@ function readBufferArray(binData, vb, typeName) {
  * Returns only the roles that need a non-zero index, so a single-UV mesh
  * yields {} and cannot fragment the material cache.
  */
+/**
+ * Sketchfab's UV transform as KHR_texture_transform.
+ *
+ * The viewer's shader computes `uv' = mat2(UVTransforms) * uv + UVOffset`, and
+ * fills that mat2 (column-major) as
+ *
+ *   vec4(cos*sx, -sin*sy, sin*sx, cos*sy)   ->   | cos*sx   sin*sx |
+ *                                                | -sin*sy  cos*sy |
+ *
+ * which is S.R: rotate, then scale. glTF specifies translation * rotation *
+ * scale, which is R.S: scale, then rotate. The rotation sign convention is the
+ * same in both, so offset, rotation and scale pass straight through, and the
+ * result is *exact* whenever the two orders commute -- no rotation, or a
+ * uniform scale. That covers plain tiling and offsetting, which is what UV
+ * transforms are nearly always used for.
+ *
+ * They do not commute for a non-uniform scale combined with a rotation, and
+ * that case is not merely reordered: S.R is a shear that R'.S' cannot equal
+ * for any r', s' unless |sx| = |sy|, so KHR_texture_transform cannot express
+ * it at all. Emitting the passthrough is still much closer than dropping the
+ * transform, but the caller is told so it can say so out loud rather than
+ * quietly shipping the wrong placement.
+ */
+export function khrTextureTransform(t) {
+    const scale = t.scale || [1, 1];
+    const offset = t.offset || [0, 0];
+    const rotation = t.rotation || 0;
+    const ext = {};
+    if (offset[0] !== 0 || offset[1] !== 0) ext.offset = [offset[0], offset[1]];
+    if (rotation !== 0) ext.rotation = rotation;
+    if (scale[0] !== 1 || scale[1] !== 1) ext.scale = [scale[0], scale[1]];
+    // S.R == R.S only when S is a true scalar. A mirrored scale such as
+    // [-2, 2] has equal magnitudes but is a reflection, and reflection does not
+    // commute with rotation.
+    const exact = rotation === 0 || scale[0] === scale[1];
+    return { ext, exact };
+}
+
 export function texCoordsForGeometry(map, uvUnits) {
     const out = {};
     const units = map && map.uvUnits;
@@ -1065,6 +1103,20 @@ function buildTextureMaps(geometries, textureList, textureFiles, viewerMaterials
                 sheen: spec.sheen
                     ? { ...spec.sheen, texture: resolveUidToBase(spec.sheen.textureUid, list) }
                     : null,
+                // Non-identity UV transform per role, for KHR_texture_transform.
+                uvTransforms: (() => {
+                    const at = (uid) =>
+                        uid && spec.uvTransforms ? spec.uvTransforms[uid] : undefined;
+                    return {
+                        albedo: at(spec.albedoUid),
+                        normal: at(spec.normalUid),
+                        metalness: at(spec.metalnessUid),
+                        emissive: at(spec.emitUid),
+                        occlusion: at(spec.aoUid),
+                        clearCoat: spec.clearCoat ? at(spec.clearCoat.textureUid) : undefined,
+                        sheen: spec.sheen ? at(spec.sheen.textureUid) : undefined,
+                    };
+                })(),
                 // Wrap mode per role, so a clamped or mirrored texture keeps
                 // its sampler instead of falling back to the global REPEAT.
                 wraps: (() => {
@@ -1183,6 +1235,28 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
     };
     // Extensions are only declared when a material actually emits one.
     const usedExtensions = new Set();
+    /**
+     * Sketchfab rotates then scales; glTF scales then rotates. With a
+     * non-uniform scale those are different transforms and no
+     * KHR_texture_transform reproduces theirs, so say so once rather than
+     * shipping a silently misplaced texture.
+     */
+    const warnedTransforms = new Set();
+    function warnInexactTransform(matName, role, t) {
+        // buildGLTF runs twice, once embedded and once external. Warn from the
+        // embedded pass only, or every note is printed in duplicate.
+        if (externalTextures) return;
+        const key = `${matName}|${role}`;
+        if (warnedTransforms.has(key)) return;
+        warnedTransforms.add(key);
+        console.warn(
+            `  Note: ${matName} ${role} combines a non-uniform scale ` +
+            `[${t.scale[0]}, ${t.scale[1]}] with a ${(t.rotation * 180 / Math.PI).toFixed(1)}deg ` +
+            'rotation. glTF applies scale before rotation and Sketchfab after, ' +
+            'so this placement cannot be reproduced exactly; exported as the ' +
+            'closest KHR_texture_transform.'
+        );
+    }
 
     const binChunks = [];
     let byteOffset = 0;
@@ -1364,6 +1438,24 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
     function makeMaterial(name, map, texCoords = {}) {
         const tc = (role) => texCoords[role] || 0;
         const wr = (role) => (map && map.wraps ? map.wraps[role] : undefined);
+        /**
+         * One glTF textureInfo: the index, which UV set it reads, and its
+         * placement on that set. Built in one place so a role cannot pick up
+         * the right sampler and the wrong transform.
+         */
+        const texInfo = (role, index) => {
+            const info = { index, texCoord: tc(role) };
+            const t = map && map.uvTransforms ? map.uvTransforms[role] : null;
+            if (t) {
+                const { ext, exact } = khrTextureTransform(t);
+                if (Object.keys(ext).length) {
+                    info.extensions = { KHR_texture_transform: ext };
+                    usedExtensions.add('KHR_texture_transform');
+                    if (!exact) warnInexactTransform(name, role, t);
+                }
+            }
+            return info;
+        };
         const baseF = (map && map.baseColorFactor) || [1, 1, 1, 1];
         const factors = pbrFactors(map);
         const material = {
@@ -1383,33 +1475,32 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             if (map.albedo) {
                 const idx = addTexture(map.albedo, { wrap: wr('albedo') });
                 if (idx >= 0) {
-                    material.pbrMetallicRoughness.baseColorTexture = { index: idx, texCoord: tc('albedo') };
+                    material.pbrMetallicRoughness.baseColorTexture = texInfo('albedo', idx);
                 }
             }
             if (map.metalness && factors.bindTexture) {
                 const idx = addTexture(map.metalness, { wrap: wr('metalness') });
                 if (idx >= 0) {
                     material.pbrMetallicRoughness.metallicRoughnessTexture = {
-                        index: idx,
-                        texCoord: tc('metalness'),
+                        ...texInfo('metalness', idx),
                     };
                 }
             }
             if (map.normal) {
                 // flipY handled when packing texture bytes (see flipNormalMapY)
                 const idx = addTexture(map.normal, { flipNormalY: !!map.normalFlipY, wrap: wr('normal') });
-                if (idx >= 0) material.normalTexture = { index: idx, texCoord: tc('normal'), scale: 1 };
+                if (idx >= 0) material.normalTexture = { ...texInfo('normal', idx), scale: 1 };
             }
             if (map.emissive) {
                 const idx = addTexture(map.emissive, { wrap: wr('emissive') });
                 if (idx >= 0) {
-                    material.emissiveTexture = { index: idx, texCoord: tc('emissive') };
+                    material.emissiveTexture = texInfo('emissive', idx);
                     material.emissiveFactor = [1, 1, 1];
                 }
             }
             if (map.occlusion) {
                 const idx = addTexture(map.occlusion, { wrap: wr('occlusion') });
-                if (idx >= 0) material.occlusionTexture = { index: idx, texCoord: tc('occlusion'), strength: 1 };
+                if (idx >= 0) material.occlusionTexture = { ...texInfo('occlusion', idx), strength: 1 };
             }
             // Opacity / cutout from viewer material
             const opType = String(map.opacityType || '');
@@ -1458,14 +1549,14 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 }
                 if (map.clearCoat.texture) {
                     const idx = addTexture(map.clearCoat.texture, { wrap: wr('clearCoat') });
-                    if (idx >= 0) ext.clearcoatTexture = { index: idx, texCoord: tc('clearCoat') };
+                    if (idx >= 0) ext.clearcoatTexture = texInfo('clearCoat', idx);
                 }
                 if (map.clearCoat.normalTexture) {
                     const idx = addTexture(map.clearCoat.normalTexture, {
                         flipNormalY: !!map.clearCoat.normalFlipY,
                         wrap: wr('clearCoat'),
                     });
-                    if (idx >= 0) ext.clearcoatNormalTexture = { index: idx, texCoord: 0 };
+                    if (idx >= 0) ext.clearcoatNormalTexture = texInfo('clearCoat', idx);
                 }
                 material.extensions = material.extensions || {};
                 material.extensions.KHR_materials_clearcoat = ext;
@@ -1478,7 +1569,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 }
                 if (map.sheen.texture) {
                     const idx = addTexture(map.sheen.texture, { wrap: wr('sheen') });
-                    if (idx >= 0) ext.sheenColorTexture = { index: idx, texCoord: tc('sheen') };
+                    if (idx >= 0) ext.sheenColorTexture = texInfo('sheen', idx);
                 }
                 material.extensions = material.extensions || {};
                 material.extensions.KHR_materials_sheen = ext;
@@ -1525,6 +1616,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                     : ''),
                 'tc:' + JSON.stringify(texCoords),
                 'wr:' + (map.wraps ? JSON.stringify(map.wraps) : ''),
+                'ut:' + (map.uvTransforms ? JSON.stringify(map.uvTransforms) : ''),
               ].join('|')
             : '__default__';
         if (matCache[key] !== undefined) return matCache[key];

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -353,6 +353,10 @@ export function texCoordsForGeometry(map, uvUnits) {
     return out;
 }
 
+/** gl.ARRAY_BUFFER / gl.ELEMENT_ARRAY_BUFFER, for bufferView.target. */
+const ARRAY_BUFFER = 34962;
+const ELEMENT_ARRAY_BUFFER = 34963;
+
 export function uvQuantBox(meta, uvSuffix) {
     const own = `uv_${uvSuffix}_`;
     if (meta[own + 'bbl_x'] !== undefined) {
@@ -1339,6 +1343,15 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         const isIndex = type === 'SCALAR' && (componentType === 5125 || componentType === 5123);
         gltf.bufferViews.push({
             buffer: 0, byteOffset, byteLength: bytes.length,
+            /**
+             * target tells a loader which GL buffer this belongs in, so it can
+             * upload straight to the GPU instead of inspecting every accessor
+             * first. It is only meaningful for vertex and index data, so it is
+             * passed in rather than inferred -- inverse bind matrices and
+             * animation curves are neither, and labelling those would be wrong
+             * rather than merely redundant.
+             */
+            ...(opts.target ? { target: opts.target } : {}),
             ...(!isIndex && !opts.noStride && itemSize > 1
                 ? { byteStride: itemSize * buf.BYTES_PER_ELEMENT }
                 : {})
@@ -1783,7 +1796,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         if (!isPoints) {
             const idx = geom.indices;
             const idxType = idx.BYTES_PER_ELEMENT === 4 ? 5125 : 5123;
-            primitive.indices = addAccessor(idx, 'SCALAR', idxType, idx.length, 1);
+            primitive.indices = addAccessor(idx, 'SCALAR', idxType, idx.length, 1, false, { target: ELEMENT_ARRAY_BUFFER });
         }
 
         // Attributes — only standard glTF attribute names (skip junk COLOR_0 already)
@@ -1798,7 +1811,8 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 ct,
                 attr.count,
                 attr.itemSize,
-                norm
+                norm,
+                { target: ARRAY_BUFFER }
             );
         }
 
@@ -1813,7 +1827,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             // synthesize 0,0 UVs so importers still bind the image node
             const nVerts = geom.attributes.POSITION.count;
             const zeros = new Float32Array(nVerts * 2);
-            primitive.attributes.TEXCOORD_0 = addAccessor(zeros, 'VEC2', 5126, nVerts, 2, false);
+            primitive.attributes.TEXCOORD_0 = addAccessor(zeros, 'VEC2', 5126, nVerts, 2, false, { target: ARRAY_BUFFER });
         }
 
         // Remove byteStride from index bufferViews (safety)
@@ -1830,10 +1844,10 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         if (geom.morphTargets && geom.morphTargets.length) {
             primitive.targets = geom.morphTargets.map((t) => {
                 const entry = {
-                    POSITION: addAccessor(t.POSITION, 'VEC3', 5126, t.count, 3, false),
+                    POSITION: addAccessor(t.POSITION, 'VEC3', 5126, t.count, 3, false, { target: ARRAY_BUFFER }),
                 };
                 if (t.NORMAL) {
-                    entry.NORMAL = addAccessor(t.NORMAL, 'VEC3', 5126, t.count, 3, false);
+                    entry.NORMAL = addAccessor(t.NORMAL, 'VEC3', 5126, t.count, 3, false, { target: ARRAY_BUFFER });
                 }
                 return entry;
             });

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -2,6 +2,10 @@ import { decodePngRgba, encodePngRgba } from './descramble.js';
 import { isPackedOrmName } from './orm.js';
 import {
     axisRotationFor,
+    IDENTITY_MAT4,
+    mat4Multiply,
+    isIdentityMat4,
+    normalMatrixFromMat4,
     isIdentityMat3,
     mat3Transpose,
     mat4FromMat3,
@@ -46,6 +50,51 @@ function typedToBytes(buf) {
 }
 
 /** Rotate POSITION/NORMAL/TANGENT in place by a column-major 3x3. */
+/**
+ * Bake a node's world placement into its vertices.
+ *
+ * The converter emits a flat list of meshes with no node hierarchy, so a mesh
+ * sitting under a transformed node has nowhere to inherit that transform from
+ * and would land at the origin. Skinned meshes are exempt: their skeleton
+ * already carries the placement, and applying it twice would double it.
+ */
+function applyPlacement(result, m) {
+    if (!m || isIdentityMat4(m)) return;
+    const nm = normalMatrixFromMat4(m);
+    const pos = result.attributes.POSITION;
+    if (pos && pos.data && (pos.itemSize || 0) >= 3) {
+        const d = pos.data;
+        const stride = pos.itemSize;
+        for (let i = 0; i < d.length; i += stride) {
+            const x = d[i];
+            const y = d[i + 1];
+            const z = d[i + 2];
+            d[i] = m[0] * x + m[4] * y + m[8] * z + m[12];
+            d[i + 1] = m[1] * x + m[5] * y + m[9] * z + m[13];
+            d[i + 2] = m[2] * x + m[6] * y + m[10] * z + m[14];
+        }
+    }
+    for (const key of ['NORMAL', 'TANGENT']) {
+        const attr = result.attributes[key];
+        if (!attr || !attr.data || (attr.itemSize || 0) < 3) continue;
+        const d = attr.data;
+        const stride = attr.itemSize;
+        for (let i = 0; i < d.length; i += stride) {
+            const x = d[i];
+            const y = d[i + 1];
+            const z = d[i + 2];
+            let nx = nm[0] * x + nm[3] * y + nm[6] * z;
+            let ny = nm[1] * x + nm[4] * y + nm[7] * z;
+            let nz = nm[2] * x + nm[5] * y + nm[8] * z;
+            const len = Math.hypot(nx, ny, nz);
+            if (len > 1e-12) { nx /= len; ny /= len; nz /= len; }
+            d[i] = nx;
+            d[i + 1] = ny;
+            d[i + 2] = nz;
+        }
+    }
+}
+
 function applyAxisRotation(result, m) {
     if (!m || isIdentityMat3(m)) return;
     for (const key of ['POSITION', 'NORMAL', 'TANGENT']) {
@@ -202,7 +251,7 @@ function readBufferArray(binData, vb, typeName) {
     return new TypedArr(binData, offset, size * itemSize);
 }
 
-function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation) {
+function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation, placement) {
     const userData = sharedState || {};
     const result = { name: geom.Name || 'unnamed', attributes: {}, indices: null, mode: 'TRIANGLES', material: null };
     const meta = {};
@@ -420,6 +469,9 @@ function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation) {
     // Baked into the vertices rather than carried on a parent matrix: it
     // matches official Sketchfab mesh bounds, and the flattened node tree has
     // nowhere to hang a transform.
+    // Placement is in the viewer's own frame, so it has to land before the
+    // model is turned into glTF's.
+    applyPlacement(result, placement);
     applyAxisRotation(result, axisRotation);
 
     return result;
@@ -1637,7 +1689,7 @@ function extractMeshGeometry(wrapper) {
     return null;
 }
 
-function collectGeometries(node, polyBin, wireBin, axisRotation) {
+function collectGeometries(node, polyBin, wireBin, axisRotation, axisNode) {
     const uidMap = {};
     buildUidMap(node, uidMap);
     resolveRefs(node, uidMap);
@@ -1647,7 +1699,7 @@ function collectGeometries(node, polyBin, wireBin, axisRotation) {
     const sharedState = { expectedState: [0] };
     const stats = { rig: 0, geom: 0, morph: 0, wire: 0, skip: 0, errors: [] };
 
-    function acceptGeometry(geom, label, rig) {
+    function acceptGeometry(geom, label, rig, placement) {
         if (!geom) return;
         if (isWireframeGeom(geom)) {
             stats.wire++;
@@ -1661,7 +1713,11 @@ function collectGeometries(node, polyBin, wireBin, axisRotation) {
         else seen.add(key);
 
         try {
-            const result = processGeometry(geom, polyBin, wireBin, sharedState, axisRotation);
+            // A skinned mesh is positioned by its skeleton, so placement is only
+            // baked for meshes that have no other way to get it.
+            const result = processGeometry(
+                geom, polyBin, wireBin, sharedState, axisRotation, rig ? null : placement
+            );
             if (result.indices && result.attributes.POSITION) {
                 // Remap _TC_* to continuous TEXCOORD_0, TEXCOORD_1, ...
                 const tcKeys = Object.keys(result.attributes)
@@ -1700,11 +1756,23 @@ function collectGeometries(node, polyBin, wireBin, axisRotation) {
      * osgAnimation.RigGeometry.SourceGeometry.osg.Geometry — those are NOT
      * direct Children of osg.Node, so a Children-only walk finds nothing.
      */
-    function walk(obj, depth) {
+    /**
+     * The axis wrapper is applied once for the whole model, so it must not be
+     * accumulated here as though it were object placement -- that would turn
+     * the model twice.
+     */
+    function placementOf(value, acc) {
+        if (!value || typeof value !== 'object') return acc;
+        if (!Array.isArray(value.Matrix) || value.Matrix.length !== 16) return acc;
+        if (value === axisNode) return acc;
+        return mat4Multiply(acc, value.Matrix);
+    }
+
+    function walk(obj, depth, acc) {
         if (!obj || typeof obj !== 'object' || depth > 60) return;
 
         if (Array.isArray(obj)) {
-            for (const item of obj) walk(item, depth + 1);
+            for (const item of obj) walk(item, depth + 1, acc);
             return;
         }
 
@@ -1713,15 +1781,15 @@ function collectGeometries(node, polyBin, wireBin, axisRotation) {
             const rig = obj['osgAnimation.RigGeometry'] || obj['osg.RigGeometry'];
             stats.rig++;
             const mesh = extractMeshGeometry(rig);
-            acceptGeometry(mesh, 'RigGeometry', rig);
+            acceptGeometry(mesh, 'RigGeometry', rig, acc);
             // Walk other fields except SourceGeometry (already handled)
             for (const [k, v] of Object.entries(rig)) {
                 if (k === 'SourceGeometry') continue;
-                walk(v, depth + 1);
+                walk(v, depth + 1, placementOf(v, acc));
             }
             for (const [k, v] of Object.entries(obj)) {
                 if (k === 'osgAnimation.RigGeometry' || k === 'osg.RigGeometry') continue;
-                walk(v, depth + 1);
+                walk(v, depth + 1, placementOf(v, acc));
             }
             return;
         }
@@ -1731,30 +1799,30 @@ function collectGeometries(node, polyBin, wireBin, axisRotation) {
             const morph = obj['osgAnimation.MorphGeometry'] || obj['osg.MorphGeometry'];
             stats.morph++;
             const mesh = extractMeshGeometry(morph) || morph;
-            acceptGeometry(mesh, 'MorphGeometry');
+            acceptGeometry(mesh, 'MorphGeometry', null, acc);
             for (const [k, v] of Object.entries(obj)) {
                 if (k === 'osgAnimation.MorphGeometry' || k === 'osg.MorphGeometry') continue;
-                walk(v, depth + 1);
+                walk(v, depth + 1, placementOf(v, acc));
             }
             // still walk morph internals except duplicate source
             for (const [k, v] of Object.entries(morph)) {
                 if (k === 'SourceGeometry') continue;
-                walk(v, depth + 1);
+                walk(v, depth + 1, placementOf(v, acc));
             }
             return;
         }
 
         if (obj['osg.Geometry']) {
             stats.geom++;
-            acceptGeometry(obj['osg.Geometry'], 'Geometry');
+            acceptGeometry(obj['osg.Geometry'], 'Geometry', null, acc);
         }
 
         for (const v of Object.values(obj)) {
-            walk(v, depth + 1);
+            walk(v, depth + 1, placementOf(v, acc));
         }
     }
 
-    walk(node, 0);
+    walk(node, 0, IDENTITY_MAT4);
 
     if (!results.length) {
         const errBits = [
@@ -1925,7 +1993,7 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
 
   // One axis decision for the whole model, read from the scene graph.
   const axis = axisRotationFor(osgjs);
-  const geometries = collectGeometries(osgjs, poly, wire, axis.matrix);
+  const geometries = collectGeometries(osgjs, poly, wire, axis.matrix, axis.node);
   const skeletons = collectSkeletons(osgjs, axis.node);
   const animationCurves = skeletons.skeletons.length
     ? buildAnimationCurves(osgjs, animationBins)

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1065,6 +1065,21 @@ function buildTextureMaps(geometries, textureList, textureFiles, viewerMaterials
                 sheen: spec.sheen
                     ? { ...spec.sheen, texture: resolveUidToBase(spec.sheen.textureUid, list) }
                     : null,
+                // Wrap mode per role, so a clamped or mirrored texture keeps
+                // its sampler instead of falling back to the global REPEAT.
+                wraps: (() => {
+                    const at = (uid) =>
+                        uid && spec.textureWraps ? spec.textureWraps[uid] : undefined;
+                    return {
+                        albedo: at(spec.albedoUid),
+                        normal: at(spec.normalUid),
+                        metalness: at(spec.metalnessUid),
+                        emissive: at(spec.emitUid),
+                        occlusion: at(spec.aoUid),
+                        clearCoat: spec.clearCoat ? at(spec.clearCoat.textureUid) : undefined,
+                        sheen: spec.sheen ? at(spec.sheen.textureUid) : undefined,
+                    };
+                })(),
                 // Which texture unit each role samples, so a material bound to
                 // a second UV set can be pointed at the right TEXCOORD_n.
                 uvUnits: (() => {
@@ -1231,12 +1246,50 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
     // importers sample badly with LINEAR_MIPMAP_LINEAR on GLB buffer images.
     gltf.samplers.push({ magFilter: 9729, minFilter: 9729, wrapS: 10497, wrapT: 10497 });
 
+    /**
+     * Sampler per distinct wrap pair, allocated on demand.
+     *
+     * Sampler 0 stays the REPEAT default and is reused for every texture that
+     * does not ask for anything else, so a model with no clamped or mirrored
+     * maps -- almost all of them -- ends up with exactly the samplers[] it had
+     * before.
+     */
+    const GL_WRAP = {
+        REPEAT: 10497,
+        CLAMP_TO_EDGE: 33071,
+        MIRRORED_REPEAT: 33648,
+    };
+    const samplerCache = { '10497|10497': 0 };
+    function samplerFor(wrap) {
+        const wrapS = GL_WRAP[wrap && wrap.wrapS] || 10497;
+        const wrapT = GL_WRAP[wrap && wrap.wrapT] || 10497;
+        const key = `${wrapS}|${wrapT}`;
+        if (samplerCache[key] !== undefined) return samplerCache[key];
+        const idx = gltf.samplers.length;
+        gltf.samplers.push({ magFilter: 9729, minFilter: 9729, wrapS, wrapT });
+        samplerCache[key] = idx;
+        return idx;
+    }
+
     // Cache filename → texture index so multi-material shares images
     const texIndexCache = Object.create(null);
 
     // Optional sync placeholder — flipNormalY applied later async-free via preprocessed textureFiles
+    /**
+     * Images are cached separately from textures.
+     *
+     * A glTF texture is an image plus a sampler, so one image used at two wrap
+     * modes is two textures -- but it must stay one image, or its bytes are
+     * embedded twice and a large albedo doubles the size of the GLB.
+     */
+    const imgIndexCache = Object.create(null);
+
     function addImage(filename, opts = {}) {
         if (!filename || !textureFiles) return -1;
+        const imgKey =
+            String(filename).split('/').pop().toLowerCase() +
+            (opts.flipNormalY ? '|fy' : '');
+        if (imgIndexCache[imgKey] !== undefined) return imgIndexCache[imgKey];
         // Prefer pre-flipped normal map when requested (keys registered as name.__flipY)
         let hit = null;
         if (opts.flipNormalY) {
@@ -1247,7 +1300,10 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             findTextureBytes('textures/' + bare + '.__flipY', textureFiles);
         }
         if (!hit) hit = findTextureBytes(filename, textureFiles);
-        if (!hit) return -1;
+        if (!hit) {
+            imgIndexCache[imgKey] = -1;
+            return -1;
+        }
         const imgData = hit.data;
         const keyName = hit.key.replace(/\.__flipY$/, '');
         const bare = textureBasename(keyName) + (opts.flipNormalY ? '_flipY' : '');
@@ -1262,6 +1318,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                 mimeType,
                 name: uriBare,
             });
+            imgIndexCache[imgKey] = imgIdx;
             return imgIdx;
         }
 
@@ -1274,13 +1331,20 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
         byteOffset += padded.length;
         binChunks.push(padded);
         gltf.images.push({ bufferView: bvIdx, mimeType, name: bare });
+        imgIndexCache[imgKey] = imgIdx;
         return imgIdx;
     }
 
     function addTexture(filename, opts = {}) {
         if (!filename) return -1;
         const flip = !!opts.flipNormalY;
-        const cacheKey = String(filename).split('/').pop().toLowerCase() + (flip ? '|fy' : '');
+        const sampler = samplerFor(opts.wrap);
+        // A glTF texture is an image *and* a sampler, so the same image used
+        // once clamped and once repeating is two textures, not one.
+        const cacheKey =
+            String(filename).split('/').pop().toLowerCase() +
+            (flip ? '|fy' : '') +
+            (sampler ? `|s${sampler}` : '');
         if (texIndexCache[cacheKey] !== undefined) return texIndexCache[cacheKey];
         const imgIdx = addImage(filename, opts);
         if (imgIdx < 0) {
@@ -1288,7 +1352,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             return -1;
         }
         const texIdx = gltf.textures.length;
-        gltf.textures.push({ source: imgIdx, sampler: 0 });
+        gltf.textures.push({ source: imgIdx, sampler });
         texIndexCache[cacheKey] = texIdx;
         return texIdx;
     }
@@ -1299,6 +1363,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
      */
     function makeMaterial(name, map, texCoords = {}) {
         const tc = (role) => texCoords[role] || 0;
+        const wr = (role) => (map && map.wraps ? map.wraps[role] : undefined);
         const baseF = (map && map.baseColorFactor) || [1, 1, 1, 1];
         const factors = pbrFactors(map);
         const material = {
@@ -1316,13 +1381,13 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
 
         if (map) {
             if (map.albedo) {
-                const idx = addTexture(map.albedo);
+                const idx = addTexture(map.albedo, { wrap: wr('albedo') });
                 if (idx >= 0) {
                     material.pbrMetallicRoughness.baseColorTexture = { index: idx, texCoord: tc('albedo') };
                 }
             }
             if (map.metalness && factors.bindTexture) {
-                const idx = addTexture(map.metalness);
+                const idx = addTexture(map.metalness, { wrap: wr('metalness') });
                 if (idx >= 0) {
                     material.pbrMetallicRoughness.metallicRoughnessTexture = {
                         index: idx,
@@ -1332,18 +1397,18 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
             }
             if (map.normal) {
                 // flipY handled when packing texture bytes (see flipNormalMapY)
-                const idx = addTexture(map.normal, { flipNormalY: !!map.normalFlipY });
+                const idx = addTexture(map.normal, { flipNormalY: !!map.normalFlipY, wrap: wr('normal') });
                 if (idx >= 0) material.normalTexture = { index: idx, texCoord: tc('normal'), scale: 1 };
             }
             if (map.emissive) {
-                const idx = addTexture(map.emissive);
+                const idx = addTexture(map.emissive, { wrap: wr('emissive') });
                 if (idx >= 0) {
                     material.emissiveTexture = { index: idx, texCoord: tc('emissive') };
                     material.emissiveFactor = [1, 1, 1];
                 }
             }
             if (map.occlusion) {
-                const idx = addTexture(map.occlusion);
+                const idx = addTexture(map.occlusion, { wrap: wr('occlusion') });
                 if (idx >= 0) material.occlusionTexture = { index: idx, texCoord: tc('occlusion'), strength: 1 };
             }
             // Opacity / cutout from viewer material
@@ -1392,12 +1457,13 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                     ext.clearcoatRoughnessFactor = map.clearCoat.roughness;
                 }
                 if (map.clearCoat.texture) {
-                    const idx = addTexture(map.clearCoat.texture);
+                    const idx = addTexture(map.clearCoat.texture, { wrap: wr('clearCoat') });
                     if (idx >= 0) ext.clearcoatTexture = { index: idx, texCoord: tc('clearCoat') };
                 }
                 if (map.clearCoat.normalTexture) {
                     const idx = addTexture(map.clearCoat.normalTexture, {
                         flipNormalY: !!map.clearCoat.normalFlipY,
+                        wrap: wr('clearCoat'),
                     });
                     if (idx >= 0) ext.clearcoatNormalTexture = { index: idx, texCoord: 0 };
                 }
@@ -1411,7 +1477,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                     ext.sheenRoughnessFactor = map.sheen.roughness;
                 }
                 if (map.sheen.texture) {
-                    const idx = addTexture(map.sheen.texture);
+                    const idx = addTexture(map.sheen.texture, { wrap: wr('sheen') });
                     if (idx >= 0) ext.sheenColorTexture = { index: idx, texCoord: tc('sheen') };
                 }
                 material.extensions = material.extensions || {};
@@ -1458,6 +1524,7 @@ function buildGLTF(geometries, textureMap, textureFiles, perGeomMaps, options = 
                     ? [map.sheen.colorFactor.join(','), map.sheen.roughness, map.sheen.texture || ''].join(',')
                     : ''),
                 'tc:' + JSON.stringify(texCoords),
+                'wr:' + (map.wraps ? JSON.stringify(map.wraps) : ''),
               ].join('|')
             : '__default__';
         if (matCache[key] !== undefined) return matCache[key];

--- a/lib/osgjs2gltf.js
+++ b/lib/osgjs2gltf.js
@@ -1,5 +1,6 @@
 import { decodePngRgba, encodePngRgba } from './descramble.js';
 import { isPackedOrmName } from './orm.js';
+import { axisRotationFor, isIdentityMat3 } from './osg-scene.js';
 
 // --- Browser helpers (Uint8Array instead of Node Buffer) ---
 function concatBytes(chunks) {
@@ -25,6 +26,25 @@ function u32le(n) {
 }
 function typedToBytes(buf) {
   return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
+/** Rotate POSITION/NORMAL/TANGENT in place by a column-major 3x3. */
+function applyAxisRotation(result, m) {
+    if (!m || isIdentityMat3(m)) return;
+    for (const key of ['POSITION', 'NORMAL', 'TANGENT']) {
+        const attr = result.attributes[key];
+        if (!attr || !attr.data || (attr.itemSize || 0) < 3) continue;
+        const d = attr.data;
+        const stride = attr.itemSize;
+        for (let i = 0; i < d.length; i += stride) {
+            const x = d[i];
+            const y = d[i + 1];
+            const z = d[i + 2];
+            d[i] = m[0] * x + m[3] * y + m[6] * z;
+            d[i + 1] = m[1] * x + m[4] * y + m[7] * z;
+            d[i + 2] = m[2] * x + m[5] * y + m[8] * z;
+        }
+    }
 }
 
 // --- Sketchfab binary decoders (extracted from viewer JS) ---
@@ -240,7 +260,7 @@ function readBufferArray(binData, vb, typeName) {
     return new TypedArr(binData, offset, size * itemSize);
 }
 
-function processGeometry(geom, polyBin, wireBin, sharedState) {
+function processGeometry(geom, polyBin, wireBin, sharedState, axisRotation) {
     const userData = sharedState || {};
     const result = { name: geom.Name || 'unnamed', attributes: {}, indices: null, mode: 'TRIANGLES', material: null };
     const meta = {};
@@ -455,21 +475,10 @@ function processGeometry(geom, polyBin, wireBin, sharedState) {
         if (m) result.materialName = m[0].replace(/_\d+$/, '');
     }
 
-    // OSG / viewer is Z-up. Official Sketchfab glTF bakes Y-up:
-    // (x, y, z) → (x, z, -y)  == rotate −90° about X.
-    // Doing it on the vertices (not a parent matrix) matches official mesh
-    // bounds and stands the model up in Blender without extra nodes.
-    for (const key of ['POSITION', 'NORMAL', 'TANGENT']) {
-        const attr = result.attributes[key];
-        if (!attr || !attr.data || (attr.itemSize || 0) < 3) continue;
-        const d = attr.data;
-        const s = attr.itemSize;
-        for (let i = 0; i < d.length; i += s) {
-            const y = d[i + 1];
-            d[i + 1] = d[i + 2];
-            d[i + 2] = -y;
-        }
-    }
+    // Baked into the vertices rather than carried on a parent matrix: it
+    // matches official Sketchfab mesh bounds, and the flattened node tree has
+    // nowhere to hang a transform.
+    applyAxisRotation(result, axisRotation);
 
     return result;
 }
@@ -1448,7 +1457,7 @@ function extractMeshGeometry(wrapper) {
     return null;
 }
 
-function collectGeometries(node, polyBin, wireBin) {
+function collectGeometries(node, polyBin, wireBin, axisRotation) {
     const uidMap = {};
     buildUidMap(node, uidMap);
     resolveRefs(node, uidMap);
@@ -1472,7 +1481,7 @@ function collectGeometries(node, polyBin, wireBin) {
         else seen.add(key);
 
         try {
-            const result = processGeometry(geom, polyBin, wireBin, sharedState);
+            const result = processGeometry(geom, polyBin, wireBin, sharedState, axisRotation);
             if (result.indices && result.attributes.POSITION) {
                 // Remap _TC_* to continuous TEXCOORD_0, TEXCOORD_1, ...
                 const tcKeys = Object.keys(result.attributes)
@@ -1659,7 +1668,9 @@ export async function convertOsgjsToGlb(osgjs, polyBin, wireBin, textureList, vi
       ? wireBin.buffer.slice(wireBin.byteOffset, wireBin.byteOffset + wireBin.byteLength)
       : wireBin);
 
-  const geometries = collectGeometries(osgjs, poly, wire);
+  // One axis decision for the whole model, read from the scene graph.
+  const axis = axisRotationFor(osgjs);
+  const geometries = collectGeometries(osgjs, poly, wire, axis.matrix);
   if (!geometries.length) {
     throw new Error(
       'No triangle geometries found in osgjs (checked osg.Geometry, RigGeometry.SourceGeometry, MorphGeometry)'

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -9,6 +9,7 @@ import {
   getDiterB,
   extractStaticKey,
   fetchTextures,
+  fetchAnimations,
   fetchBytes,
   sanitizeName,
   parseViewerMaterials,
@@ -214,6 +215,10 @@ export async function downloadModel(pageUrl, onProgress = () => {}, options = {}
       );
     }
 
+    // Animation curves live outside the .binz set; a model without them just
+    // exports its rig.
+    Object.assign(decrypted, await fetchAnimations(info, step));
+
     let wantTextures = false;
     let packMode = "full";
     let maxTextureEdge = 0;
@@ -287,12 +292,14 @@ export async function downloadModel(pageUrl, onProgress = () => {}, options = {}
 
     step("Converting osgjs → glTF (GLB)…");
     let glb;
+    let rig = null;
     let gltfExternal = null;
     let geometryCount = 0;
     let textureEmbedCount = 0;
     try {
       const result = await convertOsgjsToGlbFromFiles(decrypted, viewerMaterials, textures);
       glb = result.glb;
+      rig = result.rig || null;
       gltfExternal = result.gltfExternal || null;
       geometryCount = result.geometryCount;
       textureEmbedCount =
@@ -302,6 +309,14 @@ export async function downloadModel(pageUrl, onProgress = () => {}, options = {}
       step(
         `  GLB ready (${glb.length} bytes, ${geometryCount} mesh(es), ${textureEmbedCount} image(s) embedded)`
       );
+      if (rig && rig.bones) {
+        step(
+          `  Rig: ${rig.skins} skin(s), ${rig.bones} bone(s) in ${rig.skeletons} skeleton(s)` +
+            (rig.animations
+              ? `; ${rig.animations} animation(s), ${rig.channels} channel(s)`
+              : "; no animation curves")
+        );
+      }
       // Log material bindings for dev mode
       if (result.json && result.json.materials) {
         for (const m of result.json.materials) {
@@ -433,6 +448,9 @@ export async function downloadModel(pageUrl, onProgress = () => {}, options = {}
           pack_mode: packMode,
           max_texture_edge: maxTextureEdge || "original",
           textures_embedded_in_glb: textureEmbedCount,
+          animation_count: (rig && rig.animations) || 0,
+          skeleton_count: (rig && rig.skeletons) || 0,
+          bone_count: (rig && rig.bones) || 0,
           files: files.map((f) => f.name),
           note: glb
             ? packMode === "glb"

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -437,27 +437,42 @@ export async function fetchTextures(uid, onProgress, opts) {
     let scrambledHints = 0;
     let done = 0;
     const total = results.length;
-    const fetched = await mapPool(results, concurrency, async (tex, idx) => {
-      const i = idx + 1;
+    // Pick variants and file names before downloading: two textures can carry
+    // the same name, and resolving that inside the concurrent workers would
+    // make which one keeps the plain name depend on download order — while the
+    // loser silently overwrote the winner in the zip.
+    const usedNames = new Set();
+    const plan = results.map((tex, idx) => {
       const best = pickBestImage(tex.images || [], maxEdge, tex.pk);
       if (!best || !best.url) return null;
 
       const tuid = String(tex.uid || "").toLowerCase();
-      let base = String(tex.name || `texture_${i}`).replace(/[^\w.\-]+/g, "_");
+      let base = String(tex.name || `texture_${idx + 1}`).replace(/[^\w.\-]+/g, "_");
       const urlPath = best.url.split("?")[0];
       let ext = "";
       const mExt = base.match(/\.(png|jpe?g|webp|gif)$/i);
       if (mExt) {
         ext = mExt[0].toLowerCase().replace(".jpeg", ".jpg");
-        if (ext === ".jpeg") ext = ".jpg";
       } else {
         const uExt = (urlPath.match(/\.(png|jpe?g|webp|gif)$/i) || [])[0];
         if (uExt) ext = uExt.toLowerCase().replace(".jpeg", ".jpg");
         else ext = urlPath.includes(".png") ? ".png" : ".jpg";
         base = base + ext;
       }
+      if (usedNames.has(base.toLowerCase())) {
+        const stem = ext && base.toLowerCase().endsWith(ext)
+          ? base.slice(0, base.length - ext.length)
+          : base;
+        base = `${stem}_${tuid.slice(0, 8) || idx + 1}${ext}`;
+      }
+      usedNames.add(base.toLowerCase());
 
-      const pk = readPk(tex, best);
+      return { tex, best, base, tuid, pk: readPk(tex, best) };
+    });
+
+    const fetched = await mapPool(plan, concurrency, async (entry) => {
+      if (!entry) return null;
+      const { tex, best, base, tuid, pk } = entry;
       try {
         let bytes = await fetchBytes(best.url);
         if (!bytes || bytes.length < 32) return null;

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -275,7 +275,14 @@ export function parseViewerMaterials(info) {
       metallicFactor: typeof metalF === "number" ? metalF : 0,
       roughnessFactor,
       normalFlipY: normalCh.flipY !== false, // Sketchfab default often flipY:true
-      doubleSided: true,
+      /**
+       * Sketchfab stores the cull mode, not a sided-ness flag: DISABLE means
+       * nothing is culled, BACK means back faces are. Exporting everything
+       * double-sided lit the inside of every closed surface and made
+       * single-sided authoring intent unrecoverable. Absent means unculled,
+       * which is the viewer's own default.
+       */
+      doubleSided: mat.cullFace ? mat.cullFace === "DISABLE" : true,
       opacityEnable,
       opacityFactor,
       opacityType,

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -190,8 +190,31 @@ export function parseViewerMaterials(info) {
 
     const skipMesh = invisible || (namedVeil && !transmission);
 
+    /**
+     * Texture unit per texture, keyed by uid.
+     *
+     * Sketchfab binds each channel to a GL texture unit and stores that unit's
+     * UVs in the geometry's TexCoord<unit> attribute. The numbering is sparse
+     * -- r3_01 uses units 0, 1, 3, 5, 7, 8, 12 and 18 -- so the unit is not a
+     * UV set index and cannot be handed to glTF's texCoord as-is. Recording it
+     * lets the converter map it onto whichever index that attribute landed at.
+     *
+     * Keyed by uid rather than by channel so the role -> channel priority
+     * chains above do not have to be repeated; a uid bound to two channels at
+     * different units keeps the first, which is what the shared texture would
+     * sample anyway.
+     */
+    const texCoordUnits = {};
+    for (const c of Object.values(ch)) {
+      const t = c && c.texture;
+      if (!t || !t.uid || typeof t.texCoordUnit !== "number") continue;
+      const uid = String(t.uid).toLowerCase();
+      if (!(uid in texCoordUnits)) texCoordUnits[uid] = t.texCoordUnit;
+    }
+
     const normalCh = ch.NormalMap || {};
     out.set(name, {
+      texCoordUnits,
       id,
       name,
       albedoUid: albedo,

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -144,16 +144,24 @@ export function parseViewerMaterials(info) {
      * the companion factors only when the parent channel is on, or every
      * material picks up a stray roughness it never asked for.
      *
-     * ClearCoatNormalMap is deliberately skipped: Sketchfab exposes it but no
-     * upload can set it, so it never carries a texture.
+     * ClearCoatNormalMap can only be set in Sketchfab's own material editor --
+     * no upload format carries it -- so it is absent on almost every model and
+     * was long assumed to be unreachable. It is not: once set by hand it comes
+     * through like any other channel, and glTF has a slot for it. Read it under
+     * the same enable gate as the rest of the coat, and carry its own flipY:
+     * the editor exposes a "Flip green (-Y)" toggle per normal map, and a coat
+     * normal read with the wrong handedness reads as dents instead of bumps.
      */
     const clearCoatCh = ch.ClearCoat || {};
+    const clearCoatNormalCh = ch.ClearCoatNormalMap || {};
     const clearCoatOn = !!clearCoatCh.enable;
     const clearCoat = clearCoatOn
       ? {
           factor: typeof clearCoatCh.factor === "number" ? clearCoatCh.factor : 1,
           roughness: getFactor("ClearCoatRoughness", 0),
           textureUid: getTex("ClearCoat"),
+          normalTextureUid: getTex("ClearCoatNormalMap"),
+          normalFlipY: clearCoatNormalCh.flipY !== false,
         }
       : null;
 

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -284,20 +284,47 @@ export async function extractStaticKey(embedHtml, onProgress) {
  * Pick best image variant for a texture set.
  * Prefer max resolution; among same resolution prefer PNG (lossless) over JPEG.
  */
+/**
+ * Protection key for the chosen variant.
+ *
+ * Only the variant's own key counts — Sketchfab leaves `pk` null on the
+ * previews it serves unscrambled, and borrowing a sibling's key would
+ * "descramble" an image that was never scrambled.
+ */
 function readPk(tex, im) {
-  const vals = [];
-  if (im && im.pk != null) vals.push(im.pk);
-  if (tex && tex.pk != null) vals.push(tex.pk);
-  if (tex && tex.images) {
-    for (const x of tex.images) {
-      if (x && x.pk != null) vals.push(x.pk);
-    }
-  }
-  for (const v of vals) {
-    const n = typeof v === "number" ? v : Number(v);
-    if (Number.isFinite(n)) return n;
-  }
-  return null;
+  const own = im && Object.prototype.hasOwnProperty.call(im, "pk") ? im.pk : undefined;
+  const raw = own === undefined ? tex && tex.pk : own;
+  if (raw == null) return null;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function isPowerOfTwo(n) {
+  return n > 0 && (n & (n - 1)) === 0;
+}
+
+/**
+ * Whether a protected variant can actually be descrambled.
+ *
+ * The viewer only ever uploads power-of-two textures — WebGL1 needs them for
+ * mipmapping and REPEAT wrapping — so those are the only variants its
+ * protection shader is ever asked to reverse, and the only ones scrambled in a
+ * form that reverses. Sketchfab also keeps the raw upload at its original
+ * size; that copy is stored scrambled but nothing ever unscrambles it, and
+ * running the shader's permutation over it yields a patchwork.
+ *
+ * The permutation shuffles pixels within 8x8 tiles over a
+ * floor(w/8) x floor(h/8) grid while wrapping indices modulo w*h, so an
+ * off-grid size is not even a bijection: at 800x100 it reads 3040 pixels twice
+ * and never reads 6368 others. Power-of-two rules that out too.
+ */
+export function isDescramblable(im, texPk) {
+  if (!im) return false;
+  if (readPk({ pk: texPk }, im) == null) return true; // never scrambled
+  const w = im.width || 0;
+  const h = im.height || 0;
+  if (!w || !h) return true;
+  return isPowerOfTwo(w) && isPowerOfTwo(h);
 }
 
 function imageEdge(im) {
@@ -319,7 +346,7 @@ function scoreImage(im) {
  * maxEdge 0 / omitted = original (largest). Never downscale unless the
  * caller explicitly passes 2048 or 4096.
  */
-export function pickBestImage(images, maxEdge) {
+export function pickBestImage(images, maxEdge, texPk = null) {
   if (!images || !images.length) return null;
   const edge = maxEdge === 2048 || maxEdge === 4096 ? maxEdge : 0;
   const usable = [];
@@ -329,7 +356,9 @@ export function pickBestImage(images, maxEdge) {
     if (w > 0 && h > 0 && (w < 32 || h < 32)) continue;
     usable.push(im);
   }
-  const pool = usable.length ? usable : images.slice();
+  let pool = usable.length ? usable : images.slice();
+  const decodable = pool.filter((im) => isDescramblable(im, texPk));
+  if (decodable.length) pool = decodable;
   if (!edge) {
     let best = null;
     for (const im of pool) {
@@ -410,7 +439,7 @@ export async function fetchTextures(uid, onProgress, opts) {
     const total = results.length;
     const fetched = await mapPool(results, concurrency, async (tex, idx) => {
       const i = idx + 1;
-      const best = pickBestImage(tex.images || [], maxEdge);
+      const best = pickBestImage(tex.images || [], maxEdge, tex.pk);
       if (!best || !best.url) return null;
 
       const tuid = String(tex.uid || "").toLowerCase();

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -135,6 +135,41 @@ export function parseViewerMaterials(info) {
     const opacityType = opacity.type || alphaMask.type || "";
     const albedoFactor = getFactor("AlbedoPBR", 1);
 
+    /**
+     * Clearcoat and sheen, which glTF carries as extensions.
+     *
+     * Both are declared on every material with a default value, so presence
+     * proves nothing — only the enable flag separates a material that was
+     * authored with a clear coat from the 26 that merely have the slot. Read
+     * the companion factors only when the parent channel is on, or every
+     * material picks up a stray roughness it never asked for.
+     *
+     * ClearCoatNormalMap is deliberately skipped: Sketchfab exposes it but no
+     * upload can set it, so it never carries a texture.
+     */
+    const clearCoatCh = ch.ClearCoat || {};
+    const clearCoatOn = !!clearCoatCh.enable;
+    const clearCoat = clearCoatOn
+      ? {
+          factor: typeof clearCoatCh.factor === "number" ? clearCoatCh.factor : 1,
+          roughness: getFactor("ClearCoatRoughness", 0),
+          textureUid: getTex("ClearCoat"),
+        }
+      : null;
+
+    const sheenCh = ch.Sheen || {};
+    const sheenOn = !!sheenCh.enable;
+    const sheenColor = Array.isArray(sheenCh.color) && sheenCh.color.length >= 3
+      ? sheenCh.color.slice(0, 3)
+      : [1, 1, 1];
+    const sheen = sheenOn
+      ? {
+          colorFactor: sheenColor,
+          roughness: getFactor("SheenRoughness", 0),
+          textureUid: getTex("Sheen"),
+        }
+      : null;
+
     // Sketchfab's refraction opacity is real glass, not an invisible shell.
     // glTF expresses it with KHR_materials_transmission, so it can be exported
     // instead of dropped.
@@ -180,6 +215,8 @@ export function parseViewerMaterials(info) {
       opacityType,
       transmission,
       albedoFactor,
+      clearCoat,
+      sheen,
       skipMesh,
       // solid tint when no albedo texture
       baseColorFactor: (() => {

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -222,6 +222,7 @@ export function parseViewerMaterials(info) {
      * edge pixel, which looks like a UV bug rather than a sampler one.
      */
     const textureWraps = {};
+    const uvTransforms = {};
     for (const c of Object.values(ch)) {
       const t = c && c.texture;
       if (!t || !t.uid) continue;
@@ -232,12 +233,31 @@ export function parseViewerMaterials(info) {
       if (!(uid in textureWraps) && (t.wrapS || t.wrapT)) {
         textureWraps[uid] = { wrapS: t.wrapS || "REPEAT", wrapT: t.wrapT || "REPEAT" };
       }
+      /**
+       * UV transform, when the channel carries a non-identity one.
+       *
+       * Recorded per channel rather than per uid: the same image can be placed
+       * differently on two channels, and unlike wrap mode the transform is a
+       * property of the binding, not of the texture.
+       */
+      const uvt = c.UVTransforms;
+      if (uvt && !(uid in uvTransforms)) {
+        const scale = Array.isArray(uvt.scale) ? [uvt.scale[0], uvt.scale[1]] : [1, 1];
+        const offset = Array.isArray(uvt.offset) ? [uvt.offset[0], uvt.offset[1]] : [0, 0];
+        const rotation = typeof uvt.rotation === "number" ? uvt.rotation : 0;
+        const identity =
+          scale[0] === 1 && scale[1] === 1 &&
+          offset[0] === 0 && offset[1] === 0 &&
+          rotation === 0;
+        if (!identity) uvTransforms[uid] = { scale, offset, rotation };
+      }
     }
 
     const normalCh = ch.NormalMap || {};
     out.set(name, {
       texCoordUnits,
       textureWraps,
+      uvTransforms,
       id,
       name,
       albedoUid: albedo,

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -213,16 +213,31 @@ export function parseViewerMaterials(info) {
      * sample anyway.
      */
     const texCoordUnits = {};
+    /**
+     * Wrap mode per texture, keyed by uid.
+     *
+     * The converter used to emit one global REPEAT sampler, which is right for
+     * the overwhelming majority -- 102 of r3_01's 106 bound textures -- and
+     * silently wrong for the rest: a clamped strip tiles instead of holding its
+     * edge pixel, which looks like a UV bug rather than a sampler one.
+     */
+    const textureWraps = {};
     for (const c of Object.values(ch)) {
       const t = c && c.texture;
-      if (!t || !t.uid || typeof t.texCoordUnit !== "number") continue;
+      if (!t || !t.uid) continue;
       const uid = String(t.uid).toLowerCase();
-      if (!(uid in texCoordUnits)) texCoordUnits[uid] = t.texCoordUnit;
+      if (typeof t.texCoordUnit === "number" && !(uid in texCoordUnits)) {
+        texCoordUnits[uid] = t.texCoordUnit;
+      }
+      if (!(uid in textureWraps) && (t.wrapS || t.wrapT)) {
+        textureWraps[uid] = { wrapS: t.wrapS || "REPEAT", wrapT: t.wrapT || "REPEAT" };
+      }
     }
 
     const normalCh = ch.NormalMap || {};
     out.set(name, {
       texCoordUnits,
+      textureWraps,
       id,
       name,
       albedoUid: albedo,

--- a/lib/sf-api.js
+++ b/lib/sf-api.js
@@ -212,6 +212,85 @@ export function modelBinzUrls(info) {
   ];
 }
 
+/**
+ * Animation payload URLs for a model.
+ *
+ * Curves are not part of file.binz — each clip is a separate gzip beside the
+ * model files, named by the uid listed in options.animation.order.
+ */
+export function animationUrls(info) {
+  const order =
+    (info && info.options && info.options.animation && info.options.animation.order) || [];
+  const osgjsUrl = info && info.files && info.files[0] && info.files[0].osgjsUrl;
+  if (!order.length || !osgjsUrl) return [];
+  const base = osgjsUrl.split("/files/")[0];
+  if (!base || base === osgjsUrl) return [];
+  const seen = new Set();
+  const out = [];
+  for (const raw of order) {
+    const uid = String(raw || "").toLowerCase();
+    if (!/^[a-f0-9]{32}$/.test(uid) || seen.has(uid)) continue;
+    seen.add(uid);
+    out.push({ uid, url: `${base}/animations/${uid}.bin.gz` });
+  }
+  return out;
+}
+
+/** gzip magic, so an already-inflated body is left alone. */
+export function isGzip(bytes) {
+  return !!bytes && bytes.length > 2 && bytes[0] === 0x1f && bytes[1] === 0x8b;
+}
+
+/**
+ * Inflate a clip payload, if it still needs it.
+ *
+ * The CDN serves these with `Content-Encoding: gzip`, which fetch() honours —
+ * the body arrives already inflated and inflating it again throws. Trust the
+ * magic bytes rather than the .gz in the URL.
+ */
+async function maybeGunzip(bytes) {
+  if (!isGzip(bytes)) return bytes;
+  if (typeof DecompressionStream !== "function") {
+    throw new Error("no DecompressionStream");
+  }
+  const ds = new DecompressionStream("gzip");
+  const ab = await new Response(new Blob([bytes]).stream().pipeThrough(ds)).arrayBuffer();
+  return new Uint8Array(ab);
+}
+
+/**
+ * Download and inflate every animation clip.
+ *
+ * Keyed as `animations/<uid>.bin` to mirror how the .binz payloads are stored
+ * decompressed; the converter matches channels back by uid.
+ *
+ * @returns {Promise<Object<string, Uint8Array>>} empty when the model has none
+ */
+export async function fetchAnimations(info, onProgress) {
+  const out = {};
+  const clips = animationUrls(info);
+  if (!clips.length) return out;
+  for (const { uid, url } of clips) {
+    const short = uid.slice(0, 8);
+    try {
+      if (onProgress) onProgress(`Downloading animation ${short}…`);
+      const body = await fetchBytes(url);
+      if (!body || body.length < 8) throw new Error("empty payload");
+      const raw = await maybeGunzip(body);
+      out[`animations/${uid}.bin`] = raw;
+      if (onProgress) {
+        onProgress(`  → animations/${short}.bin (${raw.length} bytes)`);
+      }
+    } catch (e) {
+      // A missing clip costs the animation, not the model: keep going.
+      if (onProgress) {
+        onProgress(`  animation ${short} unavailable: ${e && e.message ? e.message : e}`);
+      }
+    }
+  }
+  return out;
+}
+
 export function getDiterB(info) {
   return info.files[0].p[0].b;
 }

--- a/lib/skin.js
+++ b/lib/skin.js
@@ -373,14 +373,21 @@ export function decodeChannelCurve(bin, typeName, channel) {
   const kf = channel && channel.KeyFrames;
   if (!kf || !kf.Time || !kf.Key || !channel.TargetName) return null;
 
-  const path = CHANNEL_PATHS[String(channel.Name || "").toLowerCase()];
-  if (!path) return null;
-
   const isQuat = typeName.indexOf("Quat") !== -1;
   const isFloat = typeName.indexOf("Float") !== -1;
   const itemSize = isQuat ? 4 : isFloat ? 1 : 3;
-  // glTF has no float-scalar node target; those channels are not bone TRS.
-  if (isFloat) return null;
+
+  /**
+   * A scalar channel drives one morph target's weight. Its Name is the weight
+   * index rather than a transform component, so it is TargetName that says
+   * which target it belongs to -- the caller resolves that against the mesh's
+   * target list and drops the curve if it matches none.
+   */
+  const path = isFloat
+    ? "weights"
+    : CHANNEL_PATHS[String(channel.Name || "").toLowerCase()];
+  if (!path) return null;
+
 
   const compressed = typeName.indexOf("Compressed") !== -1;
   const packed = typeName.indexOf("Packed") !== -1;

--- a/lib/skin.js
+++ b/lib/skin.js
@@ -19,6 +19,7 @@ import {
   prefixSum,
   quatAccumulate,
 } from "./osg-codec.js";
+import { IDENTITY_MAT4, mat4Multiply } from "./osg-scene.js";
 
 const TYPED_ARRAYS = {
   Float32Array,
@@ -45,21 +46,6 @@ const CHANNEL_PATHS = {
   quaternion: "rotation",
   scale: "scale",
 };
-
-const IDENTITY_MAT4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
-
-/** Column-major 4x4 product a x b (b applied first). */
-function mat4Multiply(a, b) {
-  const out = new Float64Array(16);
-  for (let c = 0; c < 4; c++) {
-    for (let r = 0; r < 4; r++) {
-      let sum = 0;
-      for (let k = 0; k < 4; k++) sum += a[k * 4 + r] * b[c * 4 + k];
-      out[c * 4 + r] = sum;
-    }
-  }
-  return out;
-}
 
 /** @param {object} node @returns {object} flattened UserDataContainer values */
 export function readUserData(node) {

--- a/lib/skin.js
+++ b/lib/skin.js
@@ -160,6 +160,16 @@ export function decomposeMatrix(m) {
  *   Each skeleton is { json, roots, bones, worldMatrix }; a bone is
  *   { name, json, trs, invBind, children, skeleton }.
  */
+/** Name on a node's animation update callback, if it has one. */
+function updateCallbackName(json) {
+  for (const cb of (json && json.UpdateCallbacks) || []) {
+    if (!cb || typeof cb !== "object") continue;
+    const value = cb[Object.keys(cb)[0]];
+    if (value && value.Name) return value.Name;
+  }
+  return "";
+}
+
 export function collectSkeletons(osgjs, axisNode = null) {
   const skeletons = [];
   const boneByName = new Map();
@@ -167,6 +177,15 @@ export function collectSkeletons(osgjs, axisNode = null) {
   function readBone(json, skeleton) {
     const bone = {
       name: json.Name || "",
+      /**
+       * The name animation channels address this bone by.
+       *
+       * It is usually the bone's own name, but not always: models imported
+       * from FBX come back with the update callback carrying a different
+       * suffix from the bone node, and channels follow the callback. Matching
+       * on the bone name alone silently loses every clip on those models.
+       */
+      animName: updateCallbackName(json) || json.Name || "",
       json,
       trs: stackedTRS(json),
       invBind: json.InvBindMatrixInSkeletonSpace || null,

--- a/lib/skin.js
+++ b/lib/skin.js
@@ -1,0 +1,207 @@
+/**
+ * Skeleton and skin extraction from Sketchfab osgjs scenes.
+ *
+ * A rigged model stores its armature as an osgAnimation.Skeleton subtree of
+ * osgAnimation.Bone nodes, and wraps every skinned mesh in an
+ * osgAnimation.RigGeometry carrying per-vertex Bones/Weights plus a BoneMap
+ * (bone name -> the index those Bones values use).
+ */
+
+const IDENTITY_MAT4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+/** Column-major 4x4 product a x b (b applied first). */
+function mat4Multiply(a, b) {
+  const out = new Float64Array(16);
+  for (let c = 0; c < 4; c++) {
+    for (let r = 0; r < 4; r++) {
+      let sum = 0;
+      for (let k = 0; k < 4; k++) sum += a[k * 4 + r] * b[c * 4 + k];
+      out[c * 4 + r] = sum;
+    }
+  }
+  return out;
+}
+
+/** Bind-pose TRS for a bone, from its UpdateBone stacked transforms. */
+export function stackedTRS(bone) {
+  const callbacks = bone.UpdateCallbacks || [];
+  let stack = null;
+  for (const cb of callbacks) {
+    const update =
+      cb && (cb["osgAnimation.UpdateBone"] || cb["osgAnimation.UpdateMatrixTransform"]);
+    if (update && update.StackedTransforms) {
+      stack = update.StackedTransforms;
+      break;
+    }
+  }
+  if (!stack) return decomposeMatrix(bone.Matrix);
+
+  let translation = null;
+  let rotation = null;
+  let scale = null;
+  let unsupported = false;
+  for (const entry of stack) {
+    const key = Object.keys(entry)[0];
+    const v = entry[key];
+    if (key === "osgAnimation.StackedTranslate") translation = v.Translate;
+    else if (key === "osgAnimation.StackedQuaternion") rotation = v.Quaternion;
+    else if (key === "osgAnimation.StackedScale") scale = v.Scale;
+    else unsupported = true;
+  }
+  // StackedRotateAxis / StackedMatrix would need composing in stack order; the
+  // bone's own Matrix already holds the composed result, so fall back to it.
+  if (unsupported) return decomposeMatrix(bone.Matrix);
+
+  return {
+    translation: translation ? Array.from(translation) : [0, 0, 0],
+    rotation: rotation ? Array.from(rotation) : [0, 0, 0, 1],
+    scale: scale ? Array.from(scale) : [1, 1, 1],
+  };
+}
+
+/** Decompose a column-major 4x4 into TRS (assumes no shear). */
+export function decomposeMatrix(m) {
+  if (!m || m.length < 16) {
+    return { translation: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1] };
+  }
+  const translation = [m[12], m[13], m[14]];
+  let sx = Math.hypot(m[0], m[1], m[2]);
+  const sy = Math.hypot(m[4], m[5], m[6]);
+  const sz = Math.hypot(m[8], m[9], m[10]);
+  // Negative determinant means one axis is mirrored; fold it into X.
+  const det =
+    m[0] * (m[5] * m[10] - m[6] * m[9]) -
+    m[4] * (m[1] * m[10] - m[2] * m[9]) +
+    m[8] * (m[1] * m[6] - m[2] * m[5]);
+  if (det < 0) sx = -sx;
+
+  const r = [
+    sx ? m[0] / sx : 0, sx ? m[1] / sx : 0, sx ? m[2] / sx : 0,
+    sy ? m[4] / sy : 0, sy ? m[5] / sy : 0, sy ? m[6] / sy : 0,
+    sz ? m[8] / sz : 0, sz ? m[9] / sz : 0, sz ? m[10] / sz : 0,
+  ];
+  const trace = r[0] + r[4] + r[8];
+  let x;
+  let y;
+  let z;
+  let w;
+  if (trace > 0) {
+    const s = Math.sqrt(trace + 1) * 2;
+    w = 0.25 * s;
+    x = (r[5] - r[7]) / s;
+    y = (r[6] - r[2]) / s;
+    z = (r[1] - r[3]) / s;
+  } else if (r[0] > r[4] && r[0] > r[8]) {
+    const s = Math.sqrt(1 + r[0] - r[4] - r[8]) * 2;
+    w = (r[5] - r[7]) / s;
+    x = 0.25 * s;
+    y = (r[3] + r[1]) / s;
+    z = (r[6] + r[2]) / s;
+  } else if (r[4] > r[8]) {
+    const s = Math.sqrt(1 + r[4] - r[0] - r[8]) * 2;
+    w = (r[6] - r[2]) / s;
+    x = (r[3] + r[1]) / s;
+    y = 0.25 * s;
+    z = (r[7] + r[5]) / s;
+  } else {
+    const s = Math.sqrt(1 + r[8] - r[0] - r[4]) * 2;
+    w = (r[1] - r[3]) / s;
+    x = (r[6] + r[2]) / s;
+    y = (r[7] + r[5]) / s;
+    z = 0.25 * s;
+  }
+  return { translation, rotation: [x, y, z, w], scale: [sx, sy, sz] };
+}
+
+/**
+ * Walk the scene and collect every skeleton with its bone hierarchy.
+ *
+ * @param {object} osgjs
+ * @param {object|null} axisNode the axis-conversion wrapper, so it is not
+ *   mistaken for placement — see findAxisConversion() in osg-scene.js
+ * @returns {{skeletons: Array, boneByName: Map<string, object>}}
+ *   Each skeleton is { json, roots, bones, worldMatrix }; a bone is
+ *   { name, json, trs, invBind, children, skeleton }.
+ */
+export function collectSkeletons(osgjs, axisNode = null) {
+  const skeletons = [];
+  const boneByName = new Map();
+
+  function readBone(json, skeleton) {
+    const bone = {
+      name: json.Name || "",
+      json,
+      trs: stackedTRS(json),
+      invBind: json.InvBindMatrixInSkeletonSpace || null,
+      children: [],
+      skeleton,
+    };
+    skeleton.bones.push(bone);
+    // Names are unique per model in Sketchfab exports (they carry a numeric
+    // suffix); first writer wins if a model ever breaks that.
+    if (bone.name && !boneByName.has(bone.name)) boneByName.set(bone.name, bone);
+    for (const child of json.Children || []) {
+      if (!child || typeof child !== "object") continue;
+      const sub = child["osgAnimation.Bone"] || child["osg.Bone"];
+      if (sub) bone.children.push(readBone(sub, skeleton));
+    }
+    return bone;
+  }
+
+  // Bones nest under the skeleton, sometimes via plain transforms; descend
+  // through anything that is not itself a bone to find the roots.
+  function findRootBones(node, skeleton, depth) {
+    if (!node || typeof node !== "object" || depth > 40) return;
+    if (Array.isArray(node)) {
+      for (const v of node) findRootBones(v, skeleton, depth + 1);
+      return;
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "osgAnimation.Bone" || key === "osg.Bone") {
+        skeleton.roots.push(readBone(value, skeleton));
+        continue; // readBone already consumed this subtree
+      }
+      findRootBones(value, skeleton, depth + 1);
+    }
+  }
+
+  // The axis-conversion wrapper is handled once for the whole model, by the
+  // vertex data and the rig root alike, so it must not be accumulated here as
+  // if it were placement.
+  function hasMatrix(value) {
+    if (!value || typeof value !== "object") return false;
+    if (!Array.isArray(value.Matrix) || value.Matrix.length !== 16) return false;
+    return value !== axisNode;
+  }
+
+  // Bone transforms are local to their skeleton, but the per-character
+  // placement lives in the osg.MatrixTransform chain above it — and the bind
+  // matrices already bake that in. Accumulate it so the rig can be placed.
+  function walk(node, depth, acc) {
+    if (!node || typeof node !== "object" || depth > 80) return;
+    if (Array.isArray(node)) {
+      for (const v of node) walk(v, depth + 1, acc);
+      return;
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "osgAnimation.Bone" || key === "osg.Bone") continue;
+      if (key === "osgAnimation.Skeleton" || key === "osg.Skeleton") {
+        const worldMatrix = hasMatrix(value) ? mat4Multiply(acc, value.Matrix) : acc;
+        const skeleton = { json: value, roots: [], bones: [], worldMatrix };
+        skeletons.push(skeleton);
+        findRootBones(value.Children || [], skeleton, 0);
+        // Keep walking for meshes and any nested skeletons.
+        for (const [k, v] of Object.entries(value)) {
+          if (k === "Children") continue;
+          walk(v, depth + 1, worldMatrix);
+        }
+        walk(value.Children || [], depth + 1, worldMatrix);
+        continue;
+      }
+      walk(value, depth + 1, hasMatrix(value) ? mat4Multiply(acc, value.Matrix) : acc);
+    }
+  }
+
+  walk(osgjs, 0, IDENTITY_MAT4);
+  return { skeletons, boneByName };
+}

--- a/lib/skin.js
+++ b/lib/skin.js
@@ -1,11 +1,50 @@
 /**
- * Skeleton and skin extraction from Sketchfab osgjs scenes.
+ * Skeleton, skin and animation extraction from Sketchfab osgjs scenes.
  *
  * A rigged model stores its armature as an osgAnimation.Skeleton subtree of
  * osgAnimation.Bone nodes, and wraps every skinned mesh in an
  * osgAnimation.RigGeometry carrying per-vertex Bones/Weights plus a BoneMap
  * (bone name -> the index those Bones values use).
+ *
+ * Animation curves do NOT live in model_file.bin — they sit in a separate
+ * `<animationUid>.bin.gz` fetched from the model's animations/ path, in one of
+ * four encodings. decodeChannelCurve() ports the viewer's reader for all four.
  */
+
+import {
+  decodeVarint,
+  deinterleave,
+  dequantize,
+  decodeSpherical,
+  prefixSum,
+  quatAccumulate,
+} from "./osg-codec.js";
+
+const TYPED_ARRAYS = {
+  Float32Array,
+  Int32Array,
+  Uint32Array,
+  Uint16Array,
+  Int16Array,
+  Uint8Array,
+  Int8Array,
+};
+
+// channel_mode bits, from the viewer's channel reader.
+const MODE_DEQUANTIZE = 1;
+const MODE_PREPEND_ORIGIN = 4;
+const MODE_SPHERICAL = 8;
+const MODE_PREPEND_TIME = 16;
+
+/** osgAnimation channel Name -> glTF animation target path. */
+const CHANNEL_PATHS = {
+  translate: "translation",
+  translation: "translation",
+  rotate: "rotation",
+  rotation: "rotation",
+  quaternion: "rotation",
+  scale: "scale",
+};
 
 const IDENTITY_MAT4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
@@ -22,13 +61,25 @@ function mat4Multiply(a, b) {
   return out;
 }
 
+/** @param {object} node @returns {object} flattened UserDataContainer values */
+export function readUserData(node) {
+  const out = {};
+  const values = node && node.UserDataContainer && node.UserDataContainer.Values;
+  if (!values) return out;
+  for (const v of values) {
+    if (!v || v.Name == null) continue;
+    const n = Number(v.Value);
+    out[v.Name] = v.Value !== "" && Number.isFinite(n) ? n : v.Value;
+  }
+  return out;
+}
+
 /** Bind-pose TRS for a bone, from its UpdateBone stacked transforms. */
 export function stackedTRS(bone) {
   const callbacks = bone.UpdateCallbacks || [];
   let stack = null;
   for (const cb of callbacks) {
-    const update =
-      cb && (cb["osgAnimation.UpdateBone"] || cb["osgAnimation.UpdateMatrixTransform"]);
+    const update = cb && (cb["osgAnimation.UpdateBone"] || cb["osgAnimation.UpdateMatrixTransform"]);
     if (update && update.StackedTransforms) {
       stack = update.StackedTransforms;
       break;
@@ -165,15 +216,6 @@ export function collectSkeletons(osgjs, axisNode = null) {
     }
   }
 
-  // The axis-conversion wrapper is handled once for the whole model, by the
-  // vertex data and the rig root alike, so it must not be accumulated here as
-  // if it were placement.
-  function hasMatrix(value) {
-    if (!value || typeof value !== "object") return false;
-    if (!Array.isArray(value.Matrix) || value.Matrix.length !== 16) return false;
-    return value !== axisNode;
-  }
-
   // Bone transforms are local to their skeleton, but the per-character
   // placement lives in the osg.MatrixTransform chain above it — and the bind
   // matrices already bake that in. Accumulate it so the rig can be placed.
@@ -202,6 +244,167 @@ export function collectSkeletons(osgjs, axisNode = null) {
     }
   }
 
+  // The axis-conversion wrapper is handled once for the whole model, by
+  // processGeometry and the rig root alike, so it must not be accumulated here
+  // as if it were placement.
+  function hasMatrix(value) {
+    if (!value || typeof value !== "object") return false;
+    if (!Array.isArray(value.Matrix) || value.Matrix.length !== 16) return false;
+    return value !== axisNode;
+  }
+
   walk(osgjs, 0, IDENTITY_MAT4);
   return { skeletons, boneByName };
+}
+
+/** Every osgAnimation.Animation in the scene, in declaration order. */
+export function collectAnimations(osgjs) {
+  const out = [];
+  function walk(node, depth) {
+    if (!node || typeof node !== "object" || depth > 80) return;
+    if (Array.isArray(node)) {
+      for (const v of node) walk(v, depth + 1);
+      return;
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "osgAnimation.Animation") {
+        out.push(value);
+        continue;
+      }
+      walk(value, depth + 1);
+    }
+  }
+  walk(osgjs, 0);
+  return out;
+}
+
+function readRaw(bin, def, typeName, count) {
+  const offset = def.Offset || 0;
+  if (def.Encoding === "varint") {
+    return decodeVarint(new Uint8Array(bin, offset), count, typeName);
+  }
+  const Ctor = TYPED_ARRAYS[typeName];
+  if (!Ctor) throw new Error(`Unknown array type: ${typeName}`);
+  // Typed array views need natural alignment; copy when the offset is odd.
+  if (offset % Ctor.BYTES_PER_ELEMENT !== 0) {
+    const bytes = new Uint8Array(bin, offset, count * Ctor.BYTES_PER_ELEMENT);
+    return new Ctor(bytes.slice().buffer);
+  }
+  return new Ctor(bin, offset, count);
+}
+
+/**
+ * Decode one KeyFrames stream (Time or Key).
+ *
+ * @param {ArrayBuffer} bin decompressed animation payload
+ * @param {object} part    KeyFrames.Time / KeyFrames.Key
+ * @param {object} userData flattened channel UserDataContainer
+ * @param {boolean} packed
+ * @param {boolean} compressed
+ * @param {number} itemSize components per output item (1 time, 3 vec3, 4 quat)
+ */
+export function decodeKeyframeArray(bin, part, userData, packed, compressed, itemSize) {
+  const encodedItemSize = part.ItemSize || 1;
+  const typeName = Object.keys(part.Array)[0];
+  const def = part.Array[typeName];
+  const size = def.Size;
+  const mode = userData.channel_mode || 0;
+  const prepend = !!(itemSize === 1 ? mode & MODE_PREPEND_TIME : mode & MODE_PREPEND_ORIGIN);
+
+  // When an origin is prepended the stream holds deltas from it, so the
+  // decoded run lands one item in and the origin fills slot 0.
+  const out = new Float32Array((prepend ? size + 1 : size) * itemSize);
+  const body = prepend ? out.subarray(itemSize) : out;
+
+  let raw = readRaw(bin, def, typeName, encodedItemSize * size);
+
+  if (itemSize === 4 && mode & MODE_SPHERICAL) {
+    if (compressed) raw = deinterleave(raw, new Float32Array(raw.length), encodedItemSize);
+    decodeSpherical(raw, body, itemSize, userData.epsilon, userData.nphi, true);
+    if (prepend) {
+      out[0] = userData.ox || 0;
+      out[1] = userData.oy || 0;
+      out[2] = userData.oz || 0;
+      out[3] = userData.ow == null ? 1 : userData.ow;
+      quatAccumulate(out);
+    }
+    return out;
+  }
+
+  if (compressed && itemSize !== 1) deinterleave(raw, body, encodedItemSize);
+  else body.set(raw);
+
+  if (packed) {
+    if (itemSize === 3 && mode & MODE_DEQUANTIZE) {
+      dequantize(
+        body,
+        body,
+        [userData.bx || 0, userData.by || 0, userData.bz || 0],
+        [userData.hx || 0, userData.hy || 0, userData.hz || 0],
+        itemSize
+      );
+    }
+    if (prepend) {
+      if (itemSize === 3) {
+        out[0] = userData.ox || 0;
+        out[1] = userData.oy || 0;
+        out[2] = userData.oz || 0;
+      } else {
+        out[0] = userData.ot || 0;
+      }
+      prefixSum(out, itemSize);
+    }
+  }
+  return out;
+}
+
+/**
+ * Decode one animation channel into glTF-ready curves.
+ *
+ * @returns {{target: string, path: string, times: Float32Array,
+ *            values: Float32Array, itemSize: number} | null}
+ */
+export function decodeChannelCurve(bin, typeName, channel) {
+  const kf = channel && channel.KeyFrames;
+  if (!kf || !kf.Time || !kf.Key || !channel.TargetName) return null;
+
+  const path = CHANNEL_PATHS[String(channel.Name || "").toLowerCase()];
+  if (!path) return null;
+
+  const isQuat = typeName.indexOf("Quat") !== -1;
+  const isFloat = typeName.indexOf("Float") !== -1;
+  const itemSize = isQuat ? 4 : isFloat ? 1 : 3;
+  // glTF has no float-scalar node target; those channels are not bone TRS.
+  if (isFloat) return null;
+
+  const compressed = typeName.indexOf("Compressed") !== -1;
+  const packed = typeName.indexOf("Packed") !== -1;
+  const userData = readUserData(channel);
+
+  const times = decodeKeyframeArray(bin, kf.Time, userData, packed, false, 1);
+  const values = decodeKeyframeArray(bin, kf.Key, userData, packed, compressed, itemSize);
+  if (!times.length || values.length < times.length * itemSize) return null;
+
+  if (isQuat) normalizeQuaternions(values);
+
+  return { target: channel.TargetName, path, times, values, itemSize };
+}
+
+/** Renormalise quaternions; accumulated deltas drift slightly. */
+export function normalizeQuaternions(values) {
+  for (let i = 0; i < values.length; i += 4) {
+    const len = Math.hypot(values[i], values[i + 1], values[i + 2], values[i + 3]);
+    if (!len) {
+      values[i] = 0;
+      values[i + 1] = 0;
+      values[i + 2] = 0;
+      values[i + 3] = 1;
+      continue;
+    }
+    values[i] /= len;
+    values[i + 1] /= len;
+    values[i + 2] /= len;
+    values[i + 3] /= len;
+  }
+  return values;
 }

--- a/lib/skin.js
+++ b/lib/skin.js
@@ -402,6 +402,46 @@ export function decodeChannelCurve(bin, typeName, channel) {
   return { target: channel.TargetName, path, times, values, itemSize };
 }
 
+/**
+ * Drop keys that do not advance the clock.
+ *
+ * glTF requires an animation's input times to be strictly increasing. Clips
+ * that arrive through Sketchfab's FBX import can key the same instant twice --
+ * a clip keyed on both a 24fps and a 30fps grid puts two keys on 1/6s -- and
+ * the viewer plays it happily, so nothing upstream rejects it. Left alone it
+ * produces a file no glTF reader will load.
+ *
+ * Where an instant repeats, the later key wins: that is the value in force from
+ * that moment onward. In practice the repeated keys hold the same value and
+ * nothing changes but the count.
+ *
+ * @returns {{times: Float32Array, values: Float32Array, dropped: number}}
+ */
+export function stripNonIncreasingKeys(times, values, itemSize) {
+  let repeats = false;
+  for (let i = 1; i < times.length; i++) {
+    if (times[i] <= times[i - 1]) { repeats = true; break; }
+  }
+  if (!repeats) return { times, values, dropped: 0 };
+
+  const outTimes = [];
+  const outValues = [];
+  for (let i = 0; i < times.length; i++) {
+    if (outTimes.length && times[i] <= outTimes[outTimes.length - 1]) {
+      const base = outValues.length - itemSize;
+      for (let c = 0; c < itemSize; c++) outValues[base + c] = values[i * itemSize + c];
+      continue;
+    }
+    outTimes.push(times[i]);
+    for (let c = 0; c < itemSize; c++) outValues.push(values[i * itemSize + c]);
+  }
+  return {
+    times: Float32Array.from(outTimes),
+    values: Float32Array.from(outValues),
+    dropped: times.length - outTimes.length,
+  };
+}
+
 /** Renormalise quaternions; accumulated deltas drift slightly. */
 export function normalizeQuaternions(values) {
   for (let i = 0; i < values.length; i += 4) {

--- a/test/animations.test.js
+++ b/test/animations.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { animationUrls, isGzip } from "../lib/sf-api.js";
+
+test("animationUrls builds one gzip URL per clip", () => {
+  const info = {
+    files: [{ osgjsUrl: "https://media.sketchfab.com/models/UID/HASH/files/F/file.binz" }],
+    options: { animation: { order: ["a".repeat(32), "b".repeat(32)] } },
+  };
+  const urls = animationUrls(info);
+  assert.equal(urls.length, 2);
+  assert.equal(
+    urls[0].url,
+    `https://media.sketchfab.com/models/UID/HASH/animations/${"a".repeat(32)}.bin.gz`
+  );
+  assert.equal(urls[0].uid, "a".repeat(32));
+});
+
+test("animationUrls is empty for a model with no clips", () => {
+  assert.deepEqual(
+    animationUrls({ files: [{ osgjsUrl: "https://x/files/y/file.binz" }], options: {} }),
+    []
+  );
+  assert.deepEqual(animationUrls({}), []);
+});
+
+test("animationUrls ignores malformed uids and duplicates", () => {
+  const info = {
+    files: [{ osgjsUrl: "https://m/models/U/H/files/F/file.binz" }],
+    options: { animation: { order: ["nope", "c".repeat(32), "c".repeat(32)] } },
+  };
+  assert.equal(animationUrls(info).length, 1);
+});
+
+test("isGzip only accepts a real gzip header", () => {
+  assert.equal(isGzip(Uint8Array.from([0x1f, 0x8b, 0x08, 0x00])), true);
+  // What fetch() hands back once the CDN's Content-Encoding has been honoured.
+  assert.equal(isGzip(Uint8Array.from([0xf8, 0x93, 0x00, 0x01])), false);
+  assert.equal(isGzip(Uint8Array.from([0x1f])), false);
+  assert.equal(isGzip(null), false);
+});

--- a/test/axis.test.js
+++ b/test/axis.test.js
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  axisRotationFor,
+  findAxisConversion,
+  isIdentityMat3,
+  mat3Multiply,
+  mat3Transpose,
+  ZUP_TO_YUP_MAT3,
+} from "../lib/osg-scene.js";
+
+const IDENTITY_MAT4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+// Sketchfab's wrapper for an uploaded glTF: Y-up content → the viewer's Z-up,
+// i.e. (x, y, z) → (x, -z, y). Column-major, as osgjs stores it.
+const YUP_TO_ZUP_MAT4 = [1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1];
+
+function rootedAt(matrix, name = "Wrapper") {
+  return {
+    "osg.Node": {
+      Children: [{ "osg.MatrixTransform": { Name: name, Matrix: matrix, Children: [] } }],
+    },
+  };
+}
+
+test("findAxisConversion spots a bare quarter turn about X", () => {
+  const node = findAxisConversion(rootedAt(YUP_TO_ZUP_MAT4));
+  assert.ok(node);
+  assert.equal(node.Name, "Wrapper");
+  // The opposite quarter turn is equally valid.
+  assert.ok(findAxisConversion(rootedAt([1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1])));
+});
+
+test("findAxisConversion ignores placement, scale and other axes", () => {
+  const turn = [1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0];
+  // Same rotation but translated — that is an object, not a conversion.
+  assert.equal(findAxisConversion(rootedAt([...turn, 5, 0, 0, 1])), null);
+  assert.equal(
+    findAxisConversion(rootedAt([2, 0, 0, 0, 0, 0, 2, 0, 0, -2, 0, 0, 0, 0, 0, 1])),
+    null
+  );
+  // Quarter turn about Z, not X.
+  assert.equal(
+    findAxisConversion(rootedAt([0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])),
+    null
+  );
+  assert.equal(findAxisConversion(rootedAt(IDENTITY_MAT4)), null);
+});
+
+test("findAxisConversion only considers the outermost transform", () => {
+  const tree = {
+    "osg.Node": {
+      Children: [
+        {
+          "osg.MatrixTransform": {
+            Name: "Placement",
+            Matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1],
+            Children: [
+              {
+                "osg.MatrixTransform": {
+                  Name: "Inner",
+                  Matrix: YUP_TO_ZUP_MAT4,
+                  Children: [],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+  assert.equal(findAxisConversion(tree), null);
+});
+
+test("findAxisConversion returns null for a scene with no transforms", () => {
+  assert.equal(findAxisConversion({ "osg.Node": { Children: [] } }), null);
+});
+
+test("a glTF-sourced model needs no turn: the wrapper already did it", () => {
+  const axis = axisRotationFor(rootedAt(YUP_TO_ZUP_MAT4));
+  assert.ok(axis.node);
+  assert.ok(isIdentityMat3(axis.matrix), `expected identity, got ${axis.matrix}`);
+});
+
+test("a Z-up model still gets the quarter turn", () => {
+  const axis = axisRotationFor(rootedAt([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 4, 0, 0, 1]));
+  assert.equal(axis.node, null);
+  assert.deepEqual(axis.matrix, ZUP_TO_YUP_MAT3);
+});
+
+test("the Z-up turn maps (x, y, z) to (x, z, -y)", () => {
+  const m = ZUP_TO_YUP_MAT3;
+  const apply = (v) => [
+    m[0] * v[0] + m[3] * v[1] + m[6] * v[2],
+    m[1] * v[0] + m[4] * v[1] + m[7] * v[2],
+    m[2] * v[0] + m[5] * v[1] + m[8] * v[2],
+  ];
+  assert.deepEqual(apply([1, 2, 3]), [1, 3, -2]);
+  // Height along +Z in a Z-up scene ends up along +Y, standing the model up.
+  assert.deepEqual(apply([0, 0, 1]), [0, 1, 0]);
+});
+
+test("transposing the axis rotation inverts it", () => {
+  const round = mat3Multiply(ZUP_TO_YUP_MAT3, mat3Transpose(ZUP_TO_YUP_MAT3));
+  assert.ok(isIdentityMat3(round));
+});

--- a/test/coat-sheen.test.js
+++ b/test/coat-sheen.test.js
@@ -1,0 +1,69 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseViewerMaterials } from "../lib/sf-api.js";
+
+/** Viewer info carrying one material with the given channels. */
+function info(channels) {
+  return { options: { materials: { m1: { name: "Mat", channels } } } };
+}
+
+const spec = (channels) => parseViewerMaterials(info(channels)).get("Mat");
+
+test("clearcoat is read when the channel is enabled", () => {
+  const s = spec({
+    ClearCoat: { enable: true, factor: 0.8, texture: { uid: "AABB" } },
+    ClearCoatRoughness: { enable: true, factor: 0.1 },
+  });
+  assert.equal(s.clearCoat.factor, 0.8);
+  assert.equal(s.clearCoat.roughness, 0.1);
+  assert.equal(s.clearCoat.textureUid, "aabb");
+});
+
+test("clearcoat is ignored when the channel is off", () => {
+  // Sketchfab declares the channel on every material, so a disabled one with a
+  // default factor must not produce a coat the author never applied.
+  const s = spec({
+    ClearCoat: { enable: false, factor: 1 },
+    ClearCoatRoughness: { enable: true, factor: 0.04 },
+  });
+  assert.equal(s.clearCoat, null);
+});
+
+test("clearcoat roughness is not borrowed by materials without a coat", () => {
+  const s = spec({ ClearCoatRoughness: { enable: true, factor: 0.04 } });
+  assert.equal(s.clearCoat, null);
+});
+
+test("clearcoat survives without a texture", () => {
+  const s = spec({ ClearCoat: { enable: true, factor: 0.5 } });
+  assert.equal(s.clearCoat.factor, 0.5);
+  assert.equal(s.clearCoat.textureUid, null);
+});
+
+test("sheen reads colour and roughness when enabled", () => {
+  const s = spec({
+    Sheen: { enable: true, color: [0.9, 0.2, 0.1] },
+    SheenRoughness: { enable: true, factor: 0.3 },
+  });
+  assert.deepEqual(s.sheen.colorFactor, [0.9, 0.2, 0.1]);
+  assert.equal(s.sheen.roughness, 0.3);
+});
+
+test("sheen defaults to white when no colour is given", () => {
+  const s = spec({ Sheen: { enable: true } });
+  assert.deepEqual(s.sheen.colorFactor, [1, 1, 1]);
+});
+
+test("sheen is ignored when the channel is off", () => {
+  const s = spec({
+    Sheen: { enable: false, color: [1, 0, 0] },
+    SheenRoughness: { enable: true, factor: 0.3 },
+  });
+  assert.equal(s.sheen, null);
+});
+
+test("a plain material gets neither extension", () => {
+  const s = spec({ AlbedoPBR: { enable: true, texture: { uid: "CCDD" } } });
+  assert.equal(s.clearCoat, null);
+  assert.equal(s.sheen, null);
+});

--- a/test/coat-sheen.test.js
+++ b/test/coat-sheen.test.js
@@ -67,3 +67,50 @@ test("a plain material gets neither extension", () => {
   assert.equal(s.clearCoat, null);
   assert.equal(s.sheen, null);
 });
+
+/* --- clearcoat normal map ------------------------------------------------ */
+
+test("the clearcoat normal map is read when the coat is on", () => {
+  // Values from M18_ClearCoat on r3_01: the channel only exists because it was
+  // switched on by hand in Sketchfab's editor, which is why it went unread for
+  // so long -- no upload format can set it.
+  const s = spec({
+    ClearCoat: { enable: true, factor: 1, texture: { uid: "01579247290247B3B9BA0E924BA99E0F" } },
+    ClearCoatRoughness: { enable: true, factor: 0.1 },
+    ClearCoatNormalMap: {
+      enable: true,
+      flipY: false,
+      texture: { uid: "5B7891C894DE467789C78DF2246ECF6A" },
+    },
+  });
+  assert.equal(s.clearCoat.normalTextureUid, "5b7891c894de467789c78df2246ecf6a");
+  assert.equal(s.clearCoat.normalFlipY, false);
+});
+
+test("the clearcoat normal map defaults to flipped green", () => {
+  // Same default as the surface normal map: absent flipY means Sketchfab's
+  // convention, which is the opposite handedness to glTF.
+  const s = spec({
+    ClearCoat: { enable: true, factor: 1 },
+    ClearCoatNormalMap: { enable: true, texture: { uid: "CCDD" } },
+  });
+  assert.equal(s.clearCoat.normalFlipY, true);
+});
+
+test("a clearcoat normal map on a material with no coat is ignored", () => {
+  // The channel is declared on every material. Without the coat itself there is
+  // no KHR_materials_clearcoat to hang it on.
+  const s = spec({
+    ClearCoat: { enable: false, factor: 1 },
+    ClearCoatNormalMap: { enable: true, texture: { uid: "CCDD" } },
+  });
+  assert.equal(s.clearCoat, null);
+});
+
+test("a disabled clearcoat normal map contributes no texture", () => {
+  const s = spec({
+    ClearCoat: { enable: true, factor: 1 },
+    ClearCoatNormalMap: { enable: false, texture: { uid: "CCDD" } },
+  });
+  assert.equal(s.clearCoat.normalTextureUid, null);
+});

--- a/test/line-geometry.test.js
+++ b/test/line-geometry.test.js
@@ -1,0 +1,98 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { convertOsgjsToGlb, shouldSkipUntexturedShell } from "../lib/osgjs2gltf.js";
+
+/**
+ * Line geometry as Sketchfab stores it: DrawElementsUByte, mode LINES, a
+ * Vertex array and nothing else. `wireframe` puts the index array in the
+ * wireframe buffer, which is the only thing separating the viewer's own
+ * overlay from an authored wireframe cube.
+ */
+function lineScene({ wireframe = false } = {}) {
+  const verts = new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]);
+  const idx = new Uint8Array([0, 1, 1, 2, 2, 3, 3, 0]); // 4 segments
+  const bin = new Uint8Array(verts.byteLength + idx.byteLength);
+  bin.set(new Uint8Array(verts.buffer), 0);
+  bin.set(idx, verts.byteLength);
+
+  const file = wireframe ? "model_file_wireframe.bin" : "model_file.bin";
+  return {
+    bin,
+    osgjs: {
+      "osg.Node": {
+        Name: "root",
+        Children: [{
+          "osg.Geometry": {
+            Name: "L01_Lines",
+            PrimitiveSetList: [{
+              DrawElementsUByte: {
+                Indices: {
+                  Array: { Uint8Array: { Offset: verts.byteLength, Size: 8, File: file } },
+                  ItemSize: 1, Type: "ELEMENT_ARRAY_BUFFER",
+                },
+                Mode: "LINES",
+              },
+            }],
+            VertexAttributeList: {
+              Vertex: {
+                Array: { Float32Array: { Offset: 0, Size: 4, File: "model_file.bin" } },
+                ItemSize: 3, Type: "ARRAY_BUFFER",
+              },
+            },
+          },
+        }],
+      },
+    },
+  };
+}
+
+test("authored line geometry converts to glTF LINES", async () => {
+  const { osgjs, bin } = lineScene();
+  const res = await convertOsgjsToGlb(osgjs, bin, bin, []);
+  assert.equal(res.geometryCount, 1);
+  const prim = res.json.meshes[0].primitives[0];
+  assert.equal(prim.mode, 1, "glTF LINES");
+  assert.equal(res.json.accessors[prim.indices].count, 8, "4 segments kept whole");
+  assert.deepEqual(Object.keys(prim.attributes), ["POSITION"]);
+});
+
+test("the viewer's wireframe overlay is still discarded", async () => {
+  // Sketchfab draws one for every geometry. Accepting LINES without checking
+  // which buffer the indices came from would give every mesh an edge-only
+  // duplicate.
+  const { osgjs, bin } = lineScene({ wireframe: true });
+  await assert.rejects(
+    () => convertOsgjsToGlb(osgjs, bin, bin, []),
+    /No triangle geometries found/,
+    "an overlay on its own leaves nothing to convert"
+  );
+});
+
+test("indices are kept as segments, not unrolled", async () => {
+  // Sketchfab expands LINE_STRIP and LINE_LOOP into explicit segments on
+  // import -- a 49-point strip arrives as 96 indices, a 5-point loop as 10
+  // with the closing edge present -- so mode 1 is all that ever arrives and
+  // there is no strip to unroll.
+  const { osgjs, bin } = lineScene();
+  const res = await convertOsgjsToGlb(osgjs, bin, bin, []);
+  const prim = res.json.meshes[0].primitives[0];
+  assert.equal(res.json.accessors[prim.indices].count % 2, 0, "whole segments");
+});
+
+test("a line material is not mistaken for an untextured shell", () => {
+  // The hair/lash heuristic looks for "line" among names, which a genuine line
+  // material matches by definition -- and lines never carry an albedo, so
+  // every one would be dropped.
+  const spec = { albedoUid: null, opacityUid: null, skipMesh: false };
+  assert.equal(shouldSkipUntexturedShell(spec, "ML01_Lines", "L01_Lines", "LINES"), false);
+  assert.equal(shouldSkipUntexturedShell(spec, "ML04_Points", "L04_Points", "POINTS"), false);
+  // Triangles keep the old behaviour.
+  assert.equal(shouldSkipUntexturedShell(spec, "Hair_line", "Hair", "TRIANGLES"), true);
+});
+
+test("an invisible line mesh is still skipped", () => {
+  // Only the name guess is scoped to triangles; a mesh the viewer hides stays
+  // hidden whatever it is drawn with.
+  const spec = { albedoUid: null, opacityUid: null, skipMesh: true };
+  assert.equal(shouldSkipUntexturedShell(spec, "ML01_Lines", "L01_Lines", "LINES"), true);
+});

--- a/test/materials.test.js
+++ b/test/materials.test.js
@@ -149,3 +149,35 @@ test("a non-refractive named glass shell is still skipped", () => {
   const spec = parseViewerMaterials(info).get("glass_rim");
   assert.equal(spec.skipMesh, true);
 });
+
+/* --- sided-ness ---------------------------------------------------------- */
+
+/** Viewer info for one material with the given top-level fields. */
+function matInfo(fields) {
+  return {
+    options: { materials: { m1: { name: "Mat", channels: {}, ...fields } } },
+  };
+}
+const sided = (fields) => parseViewerMaterials(matInfo(fields)).get("Mat").doubleSided;
+
+test("cullFace BACK means single sided", () => {
+  // Sketchfab stores the cull mode, not a sided-ness flag. Exporting
+  // everything double-sided lit the inside of every closed surface.
+  assert.equal(sided({ cullFace: "BACK" }), false);
+});
+
+test("cullFace DISABLE means double sided", () => {
+  assert.equal(sided({ cullFace: "DISABLE" }), true);
+});
+
+test("a material with no cullFace stays double sided", () => {
+  // The viewer's own default is unculled, and the permissive answer is the
+  // safe one: a wrongly single-sided mesh disappears from one side.
+  assert.equal(sided({}), true);
+});
+
+test("an unfamiliar cull mode is treated as culled", () => {
+  // FRONT and FRONT_AND_BACK both cull something, so only DISABLE is
+  // double-sided; guessing otherwise would silently re-light interiors.
+  assert.equal(sided({ cullFace: "FRONT" }), false);
+});

--- a/test/morph.test.js
+++ b/test/morph.test.js
@@ -1,0 +1,69 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sampleScalar, mergeWeightCurves } from "../lib/osgjs2gltf.js";
+
+const curve = (times, values) => ({ times, values });
+
+test("sampling returns keyed values exactly", () => {
+  assert.equal(sampleScalar([0, 1, 2], [0, 5, 10], 1), 5);
+});
+
+test("sampling interpolates between keys", () => {
+  assert.equal(sampleScalar([0, 2], [0, 10], 1), 5);
+});
+
+test("sampling clamps outside the curve", () => {
+  assert.equal(sampleScalar([1, 2], [3, 4], 0), 3);
+  assert.equal(sampleScalar([1, 2], [3, 4], 9), 4);
+});
+
+test("sampling survives a zero-length span", () => {
+  assert.equal(sampleScalar([1, 1], [7, 9], 1), 7);
+});
+
+test("weights from several targets interleave into one output", () => {
+  // glTF stores every target's weight per keyframe, so slot order has to be
+  // preserved: target 1's value must not land in target 0's position.
+  const merged = mergeWeightCurves(
+    [
+      { index: 0, curve: curve([0, 1], [0, 1]) },
+      { index: 1, curve: curve([0, 1], [1, 0]) },
+    ],
+    2
+  );
+  assert.deepEqual([...merged.times], [0, 1]);
+  assert.deepEqual([...merged.values], [0, 1, 1, 0]);
+});
+
+test("curves keyed at different times are resampled onto the union", () => {
+  const merged = mergeWeightCurves(
+    [
+      { index: 0, curve: curve([0, 2], [0, 2]) },
+      { index: 1, curve: curve([1], [9]) },
+    ],
+    2
+  );
+  assert.deepEqual([...merged.times], [0, 1, 2]);
+  // target 0 is read at t=1 where it has no key; target 1 clamps either side
+  assert.deepEqual([...merged.values], [0, 9, 1, 9, 2, 9]);
+});
+
+test("a target with no curve stays at rest instead of shifting the others", () => {
+  const merged = mergeWeightCurves([{ index: 2, curve: curve([0], [1]) }], 3);
+  assert.deepEqual([...merged.values], [0, 0, 1]);
+});
+
+test("an out-of-range slot is ignored rather than corrupting the output", () => {
+  const merged = mergeWeightCurves(
+    [
+      { index: 0, curve: curve([0], [1]) },
+      { index: 5, curve: curve([0], [1]) },
+    ],
+    2
+  );
+  assert.deepEqual([...merged.values], [1, 0]);
+});
+
+test("no keys at all yields no sampler", () => {
+  assert.equal(mergeWeightCurves([{ index: 0, curve: curve([], []) }], 1), null);
+});

--- a/test/object-animation.test.js
+++ b/test/object-animation.test.js
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { animatedTransform } from "../lib/osgjs2gltf.js";
+import { stripNonIncreasingKeys, stackedTRS } from "../lib/skin.js";
+
+const update = (name, stacked = []) => ({
+  UpdateCallbacks: [
+    { "osgAnimation.UpdateMatrixTransform": { Name: name, StackedTransforms: stacked } },
+  ],
+});
+
+test("a transform with an update callback is animatable", () => {
+  assert.equal(animatedTransform(update("Crate_7")).Name, "Crate_7");
+});
+
+test("a bone is not treated as an object animation target", () => {
+  // Bones carry UpdateBone and belong to the skeleton path. Claiming them here
+  // would emit a second node for a joint that already has one.
+  const bone = {
+    UpdateCallbacks: [{ "osgAnimation.UpdateBone": { Name: "spine", StackedTransforms: [] } }],
+  };
+  assert.equal(animatedTransform(bone), null);
+});
+
+test("a plain placement transform is not animatable", () => {
+  assert.equal(animatedTransform({ Matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 0, 0, 1] }), null);
+});
+
+test("an unnamed callback is ignored, since no channel could address it", () => {
+  assert.equal(animatedTransform({ UpdateCallbacks: [{ "osgAnimation.UpdateMatrixTransform": {} }] }), null);
+});
+
+test("non-objects are handled", () => {
+  assert.equal(animatedTransform(null), null);
+  assert.equal(animatedTransform("nope"), null);
+});
+
+test("stackedTRS reads an object transform's stack, not just a bone's", () => {
+  const trs = stackedTRS(
+    update("Crate_7", [
+      { "osgAnimation.StackedTranslate": { Translate: [-6, 1, 0] } },
+      { "osgAnimation.StackedQuaternion": { Quaternion: [0, 0, 0, 1] } },
+      { "osgAnimation.StackedScale": { Scale: [1.7, 1.2, 0.6] } },
+    ])
+  );
+  assert.deepEqual(trs.translation, [-6, 1, 0]);
+  assert.deepEqual(trs.scale, [1.7, 1.2, 0.6]);
+});
+
+// --- key times ---
+
+test("strictly increasing keys are returned untouched", () => {
+  const times = Float32Array.from([0, 1, 2]);
+  const values = Float32Array.from([0, 0, 0, 1, 1, 1, 2, 2, 2]);
+  const out = stripNonIncreasingKeys(times, values, 3);
+  assert.equal(out.dropped, 0);
+  assert.equal(out.times, times, "expected the same array back");
+});
+
+test("a repeated instant collapses to one key", () => {
+  // A clip keyed on both a 24fps and a 30fps grid lands two keys on 1/6s.
+  // glTF rejects the file outright if both survive.
+  const out = stripNonIncreasingKeys(
+    Float32Array.from([0, 0.5, 0.5, 1]),
+    Float32Array.from([0, 0, 0, 5, 5, 5, 7, 7, 7, 9, 9, 9]),
+    3
+  );
+  assert.deepEqual([...out.times], [0, 0.5, 1]);
+  assert.equal(out.dropped, 1);
+});
+
+test("the later key wins at a repeated instant", () => {
+  const out = stripNonIncreasingKeys(
+    Float32Array.from([0, 0.5, 0.5]),
+    Float32Array.from([1, 2, 3]),
+    1
+  );
+  assert.deepEqual([...out.values], [1, 3]);
+});
+
+test("a backwards key is dropped, not left to break the file", () => {
+  const out = stripNonIncreasingKeys(
+    Float32Array.from([0, 2, 1, 3]),
+    Float32Array.from([0, 2, 1, 3]),
+    1
+  );
+  assert.deepEqual([...out.times], [0, 2, 3]);
+});
+
+test("times still increase after stripping", () => {
+  const out = stripNonIncreasingKeys(
+    Float32Array.from([0, 0, 0, 1, 1, 2]),
+    Float32Array.from([0, 1, 2, 3, 4, 5]),
+    1
+  );
+  for (let i = 1; i < out.times.length; i++) {
+    assert.ok(out.times[i] > out.times[i - 1], "times must strictly increase");
+  }
+});

--- a/test/placement.test.js
+++ b/test/placement.test.js
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  IDENTITY_MAT4,
+  mat4Multiply,
+  isIdentityMat4,
+  normalMatrixFromMat4,
+} from "../lib/osg-scene.js";
+
+/** Column-major TRS-ish helper: scale then translate. */
+function scaleTranslate(sx, sy, sz, tx, ty, tz) {
+  return [sx, 0, 0, 0, 0, sy, 0, 0, 0, 0, sz, 0, tx, ty, tz, 1];
+}
+
+const apply = (m, [x, y, z]) => [
+  m[0] * x + m[4] * y + m[8] * z + m[12],
+  m[1] * x + m[5] * y + m[9] * z + m[13],
+  m[2] * x + m[6] * y + m[10] * z + m[14],
+];
+
+test("identity is recognised", () => {
+  assert.equal(isIdentityMat4(IDENTITY_MAT4), true);
+  assert.equal(isIdentityMat4(scaleTranslate(1, 1, 1, 0, 0, 1)), false);
+});
+
+test("a parent transform composes onto a child", () => {
+  // Nested placement is the case a flat converter loses: the child has to end
+  // up at parent + child, not at either one alone.
+  const parent = scaleTranslate(1, 1, 1, 10, 0, 0);
+  const child = scaleTranslate(1, 1, 1, 2, 3, 0);
+  const world = mat4Multiply(parent, child);
+  assert.deepEqual(apply(world, [0, 0, 0]), [12, 3, 0]);
+});
+
+test("scale applies before the parent's translation", () => {
+  const parent = scaleTranslate(2, 2, 2, 5, 0, 0);
+  const child = scaleTranslate(1, 1, 1, 1, 0, 0);
+  const world = mat4Multiply(parent, child);
+  assert.deepEqual(apply(world, [0, 0, 0]), [7, 0, 0]);
+});
+
+test("a point moves by the placement's translation", () => {
+  const m = scaleTranslate(1, 1, 1, -6, 1, 0);
+  assert.deepEqual(apply(m, [0.5, 0, 0]), [-5.5, 1, 0]);
+});
+
+test("uniform scale leaves the normal direction unchanged", () => {
+  const nm = normalMatrixFromMat4(scaleTranslate(2, 2, 2, 9, 9, 9));
+  const n = [nm[0] * 1 + nm[3] * 0 + nm[6] * 0, nm[1], nm[2]];
+  const len = Math.hypot(...n);
+  assert.ok(Math.abs(n[0] / len - 1) < 1e-9);
+});
+
+test("non-uniform scale tilts the normal opposite to the surface", () => {
+  // Stretching x by 2 must *shrink* the normal's x, or lighting goes wrong.
+  // Reusing the placement matrix would do the opposite, which is the bug this
+  // guards against.
+  const nm = normalMatrixFromMat4(scaleTranslate(2, 1, 1, 0, 0, 0));
+  const nx = nm[0];
+  const ny = nm[4];
+  assert.ok(nx < ny, `expected x component ${nx} to shrink relative to y ${ny}`);
+});
+
+test("a singular placement degrades instead of producing NaN", () => {
+  const nm = normalMatrixFromMat4(scaleTranslate(0, 0, 0, 1, 2, 3));
+  assert.ok(nm.every((v) => Number.isFinite(v)));
+});
+
+test("translation alone does not affect normals", () => {
+  const nm = normalMatrixFromMat4(scaleTranslate(1, 1, 1, 4, 5, 6));
+  assert.deepEqual([...nm], [1, 0, 0, 0, 1, 0, 0, 0, 1]);
+});

--- a/test/point-cloud.test.js
+++ b/test/point-cloud.test.js
@@ -1,0 +1,110 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { convertOsgjsToGlb } from "../lib/osgjs2gltf.js";
+
+/**
+ * A point cloud as Sketchfab stores one: a single osg.Geometry drawing straight
+ * from the vertex array with DrawArrays/POINTS, carrying nothing but position
+ * and colour. Shape taken from a point cloud that uploads, processes and
+ * renders on Sketchfab.
+ */
+function pointCloudScene(count = 4) {
+  const verts = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    verts[i * 3] = i;
+    verts[i * 3 + 1] = i * 2;
+    verts[i * 3 + 2] = i * 3;
+  }
+  const colors = new Uint8Array(count * 4);
+  for (let i = 0; i < count * 4; i++) colors[i] = (i * 7) % 256;
+
+  const bin = new Uint8Array(verts.byteLength + colors.byteLength);
+  bin.set(new Uint8Array(verts.buffer), 0);
+  bin.set(colors, verts.byteLength);
+
+  const osgjs = {
+    "osg.Node": {
+      Name: "root",
+      Children: [
+        {
+          "osg.Geometry": {
+            Name: "cloud",
+            PrimitiveSetList: [
+              { DrawArrays: { UniqueID: 5, Count: count, First: 0, Mode: "POINTS" } },
+            ],
+            VertexAttributeList: {
+              Vertex: {
+                Array: { Float32Array: { Offset: 0, Size: count, File: "model_file.bin" } },
+                ItemSize: 3,
+                Type: "ARRAY_BUFFER",
+              },
+              Color: {
+                Array: {
+                  Uint8Array: { Offset: verts.byteLength, Size: count, File: "model_file.bin" },
+                },
+                ItemSize: 4,
+                Type: "ARRAY_BUFFER",
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+  return { osgjs, bin, count };
+}
+
+test("a point cloud converts instead of throwing", async () => {
+  // Before: "No triangle geometries found in osgjs". Sketchfab renders these
+  // fine, so refusing them was a gap in the converter, not a limitation.
+  const { osgjs, bin, count } = pointCloudScene();
+  const res = await convertOsgjsToGlb(osgjs, bin, null, []);
+  assert.equal(res.geometryCount, 1);
+  const prim = res.json.meshes[0].primitives[0];
+  assert.equal(prim.mode, 0, "glTF POINTS");
+  assert.equal(prim.indices, undefined, "POINTS draws unindexed");
+  assert.equal(res.json.accessors[prim.attributes.POSITION].count, count);
+});
+
+test("a point cloud keeps its vertex colours", async () => {
+  // Colour is normally dropped as an engine tint. On a point cloud it is the
+  // only surface information there is, so dropping it leaves a grey blob.
+  const { osgjs, bin, count } = pointCloudScene();
+  const res = await convertOsgjsToGlb(osgjs, bin, null, []);
+  const prim = res.json.meshes[0].primitives[0];
+  const acc = res.json.accessors[prim.attributes.COLOR_0];
+  assert.ok(acc, "COLOR_0 must survive");
+  assert.equal(acc.count, count);
+  assert.equal(acc.type, "VEC4");
+  assert.equal(acc.componentType, 5121, "unsigned byte");
+  assert.equal(acc.normalized, true, "integer colours must be normalized");
+});
+
+test("vertex colour is still dropped on ordinary triangle meshes", async () => {
+  // The exception is scoped to point clouds; a textured mesh multiplied by a
+  // stray COLOR_0 renders untextured or transparent in Blender.
+  const { osgjs, bin } = pointCloudScene();
+  const idx = new Uint16Array([0, 1, 2]);
+  const withIdx = new Uint8Array(bin.byteLength + idx.byteLength);
+  withIdx.set(bin, 0);
+  withIdx.set(new Uint8Array(idx.buffer), bin.byteLength);
+
+  const geom = osgjs["osg.Node"].Children[0]["osg.Geometry"];
+  geom.PrimitiveSetList = [
+    {
+      DrawElementsUInt: {
+        Indices: {
+          Array: { Uint16Array: { Offset: bin.byteLength, Size: 3 } },
+          ItemSize: 1,
+          Type: "ELEMENT_ARRAY_BUFFER",
+        },
+        Mode: "TRIANGLES",
+      },
+    },
+  ];
+  const res = await convertOsgjsToGlb(osgjs, withIdx, null, []);
+  const prim = res.json.meshes[0].primitives[0];
+  assert.equal(prim.mode, 4);
+  assert.ok(prim.indices !== undefined, "triangles stay indexed");
+  assert.equal(prim.attributes.COLOR_0, undefined);
+});

--- a/test/point-cloud.test.js
+++ b/test/point-cloud.test.js
@@ -80,10 +80,14 @@ test("a point cloud keeps its vertex colours", async () => {
   assert.equal(acc.normalized, true, "integer colours must be normalized");
 });
 
-test("vertex colour is still dropped on ordinary triangle meshes", async () => {
-  // The exception is scoped to point clouds; a textured mesh multiplied by a
-  // stray COLOR_0 renders untextured or transparent in Blender.
+/** The same scene as a triangle mesh, with colours supplied by `fill`. */
+async function triangleWithColors(fill) {
   const { osgjs, bin } = pointCloudScene();
+  const count = 4;
+  const colors = new Uint8Array(count * 4);
+  fill(colors);
+  bin.set(colors, count * 3 * 4);
+
   const idx = new Uint16Array([0, 1, 2]);
   const withIdx = new Uint8Array(bin.byteLength + idx.byteLength);
   withIdx.set(bin, 0);
@@ -103,8 +107,37 @@ test("vertex colour is still dropped on ordinary triangle meshes", async () => {
     },
   ];
   const res = await convertOsgjsToGlb(osgjs, withIdx, null, []);
-  const prim = res.json.meshes[0].primitives[0];
+  return res.json.meshes[0].primitives[0];
+}
+
+test("a constant tint is still dropped on a triangle mesh", async () => {
+  // Sketchfab attaches a Color attribute to most geometries whether or not the
+  // author painted one. Blender multiplies baseColorTexture by COLOR_0, so
+  // exporting an unpainted tint makes a textured model look wrong.
+  const prim = await triangleWithColors((c) => c.fill(128));
   assert.equal(prim.mode, 4);
   assert.ok(prim.indices !== undefined, "triangles stay indexed");
   assert.equal(prim.attributes.COLOR_0, undefined);
+});
+
+test("genuine vertex colour survives on a triangle mesh", async () => {
+  // A painted mesh has no other record of its colour, and variation is what
+  // separates it from the engine tint.
+  const prim = await triangleWithColors((c) => {
+    for (let i = 0; i < c.length; i++) c[i] = (i * 37) % 256;
+  });
+  assert.equal(prim.mode, 4);
+  const acc = prim.attributes.COLOR_0;
+  assert.ok(acc !== undefined, "painted colour must survive");
+});
+
+test("a single-colour point cloud keeps its colour anyway", async () => {
+  // Variation is the test for triangle meshes; for a point cloud the colour is
+  // the only surface information there is, uniform or not.
+  const { osgjs, bin, count } = pointCloudScene();
+  bin.fill(200, count * 3 * 4);
+  const res = await convertOsgjsToGlb(osgjs, bin, null, []);
+  const prim = res.json.meshes[0].primitives[0];
+  assert.equal(prim.mode, 0);
+  assert.ok(prim.attributes.COLOR_0 !== undefined);
 });

--- a/test/samplers.test.js
+++ b/test/samplers.test.js
@@ -1,0 +1,129 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { convertOsgjsToGlb } from "../lib/osgjs2gltf.js";
+
+const PNG_1X1 = Uint8Array.from(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+    "base64"
+  )
+);
+
+/** One triangle per material name, all sharing a single image. */
+function scene(names) {
+  const verts = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const idx = new Uint16Array([0, 1, 2]);
+  const bin = new Uint8Array(verts.byteLength + idx.byteLength);
+  bin.set(new Uint8Array(verts.buffer), 0);
+  bin.set(new Uint8Array(idx.buffer), verts.byteLength);
+
+  // Float32Array views must start on a 4-byte boundary, so the index block is
+  // padded before the UVs rather than packed tight.
+  const uvOffset = (bin.byteLength + 3) & ~3;
+  const uv = new Float32Array([0, 0, 1, 0, 0, 1]);
+  const bin2 = new Uint8Array(uvOffset + uv.byteLength);
+  bin2.set(bin, 0);
+  bin2.set(new Uint8Array(uv.buffer), uvOffset);
+
+  return {
+    bin: bin2,
+    osgjs: {
+      "osg.Node": {
+        Name: "root",
+        Children: names.map((n) => ({
+          "osg.Geometry": {
+            Name: n,
+            PrimitiveSetList: [
+              {
+                DrawElementsUInt: {
+                  Indices: {
+                    Array: { Uint16Array: { Offset: verts.byteLength, Size: 3 } },
+                    ItemSize: 1,
+                    Type: "ELEMENT_ARRAY_BUFFER",
+                  },
+                  Mode: "TRIANGLES",
+                },
+              },
+            ],
+            VertexAttributeList: {
+              Vertex: {
+                Array: { Float32Array: { Offset: 0, Size: 3 } },
+                ItemSize: 3,
+                Type: "ARRAY_BUFFER",
+              },
+              TexCoord0: {
+                Array: { Float32Array: { Offset: uvOffset, Size: 3 } },
+                ItemSize: 2,
+                Type: "ARRAY_BUFFER",
+              },
+            },
+          },
+        })),
+      },
+    },
+  };
+}
+
+const TEX_UID = "3e340a3cbe1348c489f7a48af9039d5b";
+const textures = [{ uid: TEX_UID, name: "albedo_pot_strip.png", data: PNG_1X1 }];
+
+/** A viewer material bound to the shared image with the given wrap mode. */
+function material(name, wrap) {
+  return [
+    name,
+    {
+      id: name,
+      name,
+      albedoUid: TEX_UID,
+      textureWraps: { [TEX_UID]: wrap },
+      texCoordUnits: { [TEX_UID]: 0 },
+      metallicFactor: 0,
+      roughnessFactor: 0.9,
+      baseColorFactor: [1, 1, 1, 1],
+    },
+  ];
+}
+
+test("a repeating texture reuses the default sampler", async () => {
+  const { osgjs, bin } = scene(["Mat"]);
+  const vm = new Map([material("Mat", { wrapS: "REPEAT", wrapT: "REPEAT" })]);
+  const res = await convertOsgjsToGlb(osgjs, bin, null, textures, vm);
+  assert.equal(res.json.samplers.length, 1, "no extra sampler for the default");
+  assert.equal(res.json.textures[0].sampler, 0);
+});
+
+test("clamp and mirror each get their own sampler", async () => {
+  const { osgjs, bin } = scene(["Clamped", "Mirrored"]);
+  const vm = new Map([
+    material("Clamped", { wrapS: "CLAMP_TO_EDGE", wrapT: "CLAMP_TO_EDGE" }),
+    material("Mirrored", { wrapS: "MIRRORED_REPEAT", wrapT: "MIRRORED_REPEAT" }),
+  ]);
+  const res = await convertOsgjsToGlb(osgjs, bin, null, textures, vm);
+  const wraps = res.json.samplers.map((s) => `${s.wrapS}/${s.wrapT}`);
+  assert.ok(wraps.includes("33071/33071"), "CLAMP_TO_EDGE");
+  assert.ok(wraps.includes("33648/33648"), "MIRRORED_REPEAT");
+});
+
+test("one image used at two wrap modes becomes two textures, one source", async () => {
+  // A glTF texture is an image plus a sampler. Sharing the texture entry would
+  // silently give both materials whichever wrap mode was written first.
+  const { osgjs, bin } = scene(["Clamped", "Repeating"]);
+  const vm = new Map([
+    material("Clamped", { wrapS: "CLAMP_TO_EDGE", wrapT: "CLAMP_TO_EDGE" }),
+    material("Repeating", { wrapS: "REPEAT", wrapT: "REPEAT" }),
+  ]);
+  const res = await convertOsgjsToGlb(osgjs, bin, null, textures, vm);
+  assert.equal(res.json.textures.length, 2);
+  assert.equal(res.json.images.length, 1, "the image itself is embedded once");
+  const samplers = new Set(res.json.textures.map((t) => t.sampler));
+  assert.equal(samplers.size, 2);
+});
+
+test("mixed wrap axes are kept apart", async () => {
+  const { osgjs, bin } = scene(["Mat"]);
+  const vm = new Map([material("Mat", { wrapS: "CLAMP_TO_EDGE", wrapT: "REPEAT" })]);
+  const res = await convertOsgjsToGlb(osgjs, bin, null, textures, vm);
+  const s = res.json.samplers[res.json.textures[0].sampler];
+  assert.equal(s.wrapS, 33071);
+  assert.equal(s.wrapT, 10497);
+});

--- a/test/skin.test.js
+++ b/test/skin.test.js
@@ -27,7 +27,7 @@ function bone(name, opts = {}) {
     UpdateCallbacks: [
       {
         "osgAnimation.UpdateBone": {
-          Name: name,
+          Name: opts.animName || name,
           StackedTransforms: [
             { "osgAnimation.StackedTranslate": { Translate: opts.t || [0, 0, 0] } },
             { "osgAnimation.StackedQuaternion": { Quaternion: opts.q || [0, 0, 0, 1] } },
@@ -300,4 +300,31 @@ test("normalizeQuaternions repairs zero-length keys", () => {
   normalizeQuaternions(v);
   assert.deepEqual(Array.from(v.slice(0, 4)), [0, 0, 0, 1]);
   assert.deepEqual(Array.from(v.slice(4, 8)), [1, 0, 0, 0]);
+});
+
+test("a bone records the name its animation channels use", () => {
+  const tree = scene([{ "osgAnimation.Bone": bone("bone_00_01") }]);
+  const { skeletons } = collectSkeletons(tree);
+  assert.equal(skeletons[0].bones[0].animName, "bone_00_01");
+});
+
+test("animName follows the update callback when it differs from the bone", () => {
+  // Models imported from FBX come back with the callback carrying a different
+  // suffix from the bone node, and channels address the callback. Matching on
+  // the bone name alone loses every clip on those models.
+  const tree = scene([
+    { "osgAnimation.Bone": bone("bone_00_01", { animName: "bone_00_12" }) },
+  ]);
+  const { skeletons } = collectSkeletons(tree);
+  const b = skeletons[0].bones[0];
+  assert.equal(b.name, "bone_00_01");
+  assert.equal(b.animName, "bone_00_12");
+});
+
+test("a bone with no update callback falls back to its own name", () => {
+  const tree = scene([
+    { "osgAnimation.Bone": { Name: "plain", Matrix: IDENTITY, Children: [] } },
+  ]);
+  const { skeletons } = collectSkeletons(tree);
+  assert.equal(skeletons[0].bones[0].animName, "plain");
 });

--- a/test/skin.test.js
+++ b/test/skin.test.js
@@ -257,8 +257,25 @@ test("decodeChannelCurve skips channels glTF cannot target", () => {
       Key: { ItemSize: 1, Array: { Float32Array: { Offset: 8, Size: 2 } } },
     },
   });
-  assert.equal(decodeChannelCurve(bin, "osgAnimation.FloatLerpChannel", mk("weight")), null);
   assert.equal(decodeChannelCurve(bin, "osgAnimation.Vec3LerpChannel", mk("mystery")), null);
+});
+
+test("a scalar channel decodes as a morph weight curve", () => {
+  // The channel's Name is a weight index, not a transform component, so the
+  // path comes from the channel being scalar rather than from a name lookup.
+  const bin = f32Buffer([0, 1, 2, 3]);
+  const curve = decodeChannelCurve(bin, "osgAnimation.FloatLerpChannel", {
+    Name: "0",
+    TargetName: "target_12_0_0",
+    KeyFrames: {
+      Time: { ItemSize: 1, Array: { Float32Array: { Offset: 0, Size: 2 } } },
+      Key: { ItemSize: 1, Array: { Float32Array: { Offset: 8, Size: 2 } } },
+    },
+  });
+  assert.ok(curve, "expected a curve");
+  assert.equal(curve.path, "weights");
+  assert.equal(curve.itemSize, 1);
+  assert.equal(curve.target, "target_12_0_0");
 });
 
 // --- codec primitives ---

--- a/test/skin.test.js
+++ b/test/skin.test.js
@@ -1,6 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { collectSkeletons, decomposeMatrix, stackedTRS } from "../lib/skin.js";
+import {
+  collectAnimations,
+  collectSkeletons,
+  decodeChannelCurve,
+  decodeKeyframeArray,
+  decomposeMatrix,
+  normalizeQuaternions,
+  stackedTRS,
+} from "../lib/skin.js";
+import {
+  deinterleave,
+  prefixSum,
+  quatAccumulate,
+  decodeSpherical,
+} from "../lib/osg-codec.js";
 import { findAxisConversion } from "../lib/osg-scene.js";
 
 const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
@@ -138,4 +152,152 @@ test("decomposeMatrix recovers translation, rotation and scale", () => {
   for (const s of d.scale) assert.ok(Math.abs(s - 2) < 1e-6);
   assert.ok(Math.abs(Math.hypot(...d.rotation) - 1) < 1e-6);
   assert.ok(Math.abs(Math.abs(d.rotation[2]) - Math.SQRT1_2) < 1e-6);
+});
+
+// --- animations ---
+
+test("collectAnimations finds every animation", () => {
+  const tree = {
+    "osg.Node": {
+      Children: [
+        {
+          "osgAnimation.BasicAnimationManager": {
+            Animations: [
+              { "osgAnimation.Animation": { Name: "walk", Channels: [] } },
+              { "osgAnimation.Animation": { Name: "run", Channels: [] } },
+            ],
+          },
+        },
+      ],
+    },
+  };
+  assert.deepEqual(collectAnimations(tree).map((a) => a.Name), ["walk", "run"]);
+});
+
+function f32Buffer(values) {
+  return Float32Array.from(values).buffer;
+}
+
+test("plain keyframe arrays pass through untouched", () => {
+  const bin = f32Buffer([1, 2, 3, 4, 5, 6]);
+  const part = { ItemSize: 3, Array: { Float32Array: { Offset: 0, Size: 2 } } };
+  const out = decodeKeyframeArray(bin, part, {}, false, false, 3);
+  assert.deepEqual(Array.from(out), [1, 2, 3, 4, 5, 6]);
+});
+
+test("packed time keys prepend the origin and accumulate deltas", () => {
+  const bin = f32Buffer([0.1, 0.1, 0.1]);
+  const part = { ItemSize: 1, Array: { Float32Array: { Offset: 0, Size: 3 } } };
+  // channel_mode 16 = prepend origin for scalar time
+  const out = decodeKeyframeArray(bin, part, { channel_mode: 16, ot: 0.5 }, true, false, 1);
+  assert.equal(out.length, 4);
+  const expected = [0.5, 0.6, 0.7, 0.8];
+  out.forEach((v, i) => assert.ok(Math.abs(v - expected[i]) < 1e-5, `${v} != ${expected[i]}`));
+});
+
+test("compressed packed vec3 keys de-interleave, dequantize, then accumulate", () => {
+  // planar: all x, then all y, then all z
+  const bin = Uint16Array.from([10, 20, 0, 0, 0, 0]).buffer;
+  const part = { ItemSize: 3, Array: { Uint16Array: { Offset: 0, Size: 2 } } };
+  const userData = {
+    channel_mode: 1 | 4, // dequantize + prepend origin
+    bx: 1, by: 0, bz: 0,
+    hx: 0.5, hy: 1, hz: 1,
+    ox: 100, oy: 0, oz: 0,
+  };
+  const out = decodeKeyframeArray(bin, part, userData, true, true, 3);
+  assert.equal(out.length, 9);
+  assert.deepEqual(Array.from(out.slice(0, 3)), [100, 0, 0]);
+  assert.deepEqual(Array.from(out.slice(3, 6)), [106, 0, 0]);
+  assert.deepEqual(Array.from(out.slice(6, 9)), [117, 0, 0]);
+});
+
+test("spherical quaternion keys decode to unit quaternions", () => {
+  const bin = Uint16Array.from([120, 300, 40, 90, 260, 20]).buffer;
+  const part = { ItemSize: 3, Array: { Uint16Array: { Offset: 0, Size: 2 } } };
+  const userData = {
+    channel_mode: 8 | 4, // spherical + prepend origin
+    epsilon: 0.25,
+    nphi: 720,
+    ox: 0, oy: 0, oz: 0, ow: 1,
+  };
+  const out = decodeKeyframeArray(bin, part, userData, true, true, 4);
+  assert.equal(out.length, 12);
+  for (let i = 0; i < out.length; i += 4) {
+    const len = Math.hypot(out[i], out[i + 1], out[i + 2], out[i + 3]);
+    assert.ok(Math.abs(len - 1) < 1e-4, `quaternion ${i / 4} length ${len}`);
+  }
+});
+
+test("decodeChannelCurve maps osgAnimation names to glTF paths", () => {
+  const bin = f32Buffer([0, 1, /* values */ 1, 2, 3, 4, 5, 6]);
+  const channel = {
+    Name: "translate",
+    TargetName: "spine",
+    KeyFrames: {
+      Time: { ItemSize: 1, Array: { Float32Array: { Offset: 0, Size: 2 } } },
+      Key: { ItemSize: 3, Array: { Float32Array: { Offset: 8, Size: 2 } } },
+    },
+  };
+  const curve = decodeChannelCurve(bin, "osgAnimation.Vec3LerpChannel", channel);
+  assert.equal(curve.path, "translation");
+  assert.equal(curve.target, "spine");
+  assert.equal(curve.itemSize, 3);
+  assert.deepEqual(Array.from(curve.times), [0, 1]);
+  assert.deepEqual(Array.from(curve.values), [1, 2, 3, 4, 5, 6]);
+});
+
+test("decodeChannelCurve skips channels glTF cannot target", () => {
+  const bin = f32Buffer([0, 1, 2, 3]);
+  const mk = (name) => ({
+    Name: name,
+    TargetName: "spine",
+    KeyFrames: {
+      Time: { ItemSize: 1, Array: { Float32Array: { Offset: 0, Size: 2 } } },
+      Key: { ItemSize: 1, Array: { Float32Array: { Offset: 8, Size: 2 } } },
+    },
+  });
+  assert.equal(decodeChannelCurve(bin, "osgAnimation.FloatLerpChannel", mk("weight")), null);
+  assert.equal(decodeChannelCurve(bin, "osgAnimation.Vec3LerpChannel", mk("mystery")), null);
+});
+
+// --- codec primitives ---
+
+test("deinterleave converts planar streams to interleaved items", () => {
+  const src = Float32Array.from([1, 2, 10, 20, 100, 200]);
+  const out = deinterleave(src, new Float32Array(6), 3);
+  assert.deepEqual(Array.from(out), [1, 10, 100, 2, 20, 200]);
+});
+
+test("prefixSum accumulates per component", () => {
+  const arr = Float32Array.from([1, 2, 1, 2, 1, 2]);
+  assert.deepEqual(Array.from(prefixSum(arr, 2)), [1, 2, 2, 4, 3, 6]);
+});
+
+test("quatAccumulate composes each key onto the previous", () => {
+  // 45° about Z, applied twice, gives 90° about Z
+  const q45 = [0, 0, Math.sin(Math.PI / 8), Math.cos(Math.PI / 8)];
+  const arr = Float32Array.from([...q45, ...q45]);
+  quatAccumulate(arr);
+  assert.ok(Math.abs(arr[6] - Math.SQRT1_2) < 1e-6, `z ${arr[6]}`);
+  assert.ok(Math.abs(arr[7] - Math.SQRT1_2) < 1e-6, `w ${arr[7]}`);
+});
+
+test("decodeSpherical keeps the tangent handedness branch intact", () => {
+  // itemSize 4 without a third component is the tangent path: sign in bit 1024
+  const out = new Float32Array(8);
+  decodeSpherical(Uint16Array.from([100 | 1024, 50, 100, 50]), out, 4, 0.25, 720, false);
+  assert.equal(out[3], -1);
+  assert.equal(out[7], 1);
+  for (const base of [0, 4]) {
+    const len = Math.hypot(out[base], out[base + 1], out[base + 2]);
+    assert.ok(Math.abs(len - 1) < 1e-4, `direction ${base} length ${len}`);
+  }
+});
+
+test("normalizeQuaternions repairs zero-length keys", () => {
+  const v = Float32Array.from([0, 0, 0, 0, 2, 0, 0, 0]);
+  normalizeQuaternions(v);
+  assert.deepEqual(Array.from(v.slice(0, 4)), [0, 0, 0, 1]);
+  assert.deepEqual(Array.from(v.slice(4, 8)), [1, 0, 0, 0]);
 });

--- a/test/skin.test.js
+++ b/test/skin.test.js
@@ -1,0 +1,141 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { collectSkeletons, decomposeMatrix, stackedTRS } from "../lib/skin.js";
+import { findAxisConversion } from "../lib/osg-scene.js";
+
+const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+function bone(name, opts = {}) {
+  return {
+    Name: name,
+    Matrix: opts.matrix || IDENTITY,
+    InvBindMatrixInSkeletonSpace: opts.invBind || IDENTITY,
+    UpdateCallbacks: [
+      {
+        "osgAnimation.UpdateBone": {
+          Name: name,
+          StackedTransforms: [
+            { "osgAnimation.StackedTranslate": { Translate: opts.t || [0, 0, 0] } },
+            { "osgAnimation.StackedQuaternion": { Quaternion: opts.q || [0, 0, 0, 1] } },
+            { "osgAnimation.StackedScale": { Scale: opts.s || [1, 1, 1] } },
+          ],
+        },
+      },
+    ],
+    Children: opts.children || [],
+  };
+}
+
+function scene(skeletonChildren, placement) {
+  return {
+    "osg.Node": {
+      Children: [
+        {
+          "osg.MatrixTransform": {
+            Name: "GLTF_SceneRootNode",
+            // Sketchfab's Y-up → viewer Z-up wrapper.
+            Matrix: [1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1],
+            Children: [
+              {
+                "osg.MatrixTransform": {
+                  Name: "Placement",
+                  Matrix: placement || IDENTITY,
+                  Children: [
+                    {
+                      "osgAnimation.Skeleton": {
+                        Name: "Sk",
+                        Matrix: IDENTITY,
+                        Children: skeletonChildren,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
+test("collectSkeletons reads the bone tree and keeps names unique", () => {
+  const tree = scene([
+    { "osgAnimation.Bone": bone("root", { children: [{ "osgAnimation.Bone": bone("child") }] }) },
+  ]);
+  const { skeletons, boneByName } = collectSkeletons(tree);
+  assert.equal(skeletons.length, 1);
+  assert.equal(skeletons[0].bones.length, 2);
+  assert.equal(skeletons[0].roots.length, 1);
+  assert.equal(skeletons[0].roots[0].name, "root");
+  assert.equal(skeletons[0].roots[0].children[0].name, "child");
+  assert.ok(boneByName.has("child"));
+});
+
+test("skeleton placement accumulates transforms but skips the axis conversion", () => {
+  const placement = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 2, 0, -3, 1];
+  const tree = scene([{ "osgAnimation.Bone": bone("root") }], placement);
+  const { skeletons } = collectSkeletons(tree, findAxisConversion(tree));
+  const w = skeletons[0].worldMatrix;
+  // Placement survives; the conversion must not be folded in, or the rig
+  // would be turned twice relative to the baked vertices.
+  assert.deepEqual([w[12], w[13], w[14]], [2, 0, -3]);
+  assert.deepEqual([w[0], w[5], w[10]], [1, 1, 1]);
+});
+
+test("without a conversion node every transform counts as placement", () => {
+  const placement = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 2, 0, -3, 1];
+  const tree = scene([{ "osgAnimation.Bone": bone("root") }], placement);
+  const { skeletons } = collectSkeletons(tree, null);
+  const w = skeletons[0].worldMatrix;
+  // The wrapper's quarter turn now applies: (2, 0, -3) → (2, 3, 0).
+  assert.deepEqual([w[12], w[13], w[14]], [2, 3, 0]);
+});
+
+test("a mesh under the skeleton is not mistaken for a bone", () => {
+  const tree = scene([
+    { "osgAnimation.Bone": bone("root") },
+    { "osg.MatrixTransform": { Name: "MeshHolder", Matrix: IDENTITY, Children: [] } },
+  ]);
+  const { skeletons } = collectSkeletons(tree);
+  assert.equal(skeletons[0].roots.length, 1);
+  assert.equal(skeletons[0].bones.length, 1);
+});
+
+test("every bone carries its inverse bind matrix", () => {
+  const invBind = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -1, -2, -3, 1];
+  const tree = scene([{ "osgAnimation.Bone": bone("root", { invBind }) }]);
+  const { boneByName } = collectSkeletons(tree);
+  assert.deepEqual(boneByName.get("root").invBind, invBind);
+});
+
+test("stackedTRS reads translate/rotate/scale", () => {
+  const trs = stackedTRS(bone("b", { t: [1, 2, 3], q: [0, 0, 0, 1], s: [2, 2, 2] }));
+  assert.deepEqual(trs.translation, [1, 2, 3]);
+  assert.deepEqual(trs.scale, [2, 2, 2]);
+});
+
+test("stackedTRS falls back to the matrix for unsupported stacked types", () => {
+  const b = {
+    Name: "b",
+    Matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 6, 7, 1],
+    UpdateCallbacks: [
+      {
+        "osgAnimation.UpdateBone": {
+          StackedTransforms: [{ "osgAnimation.StackedRotateAxis": { Axis: [0, 1, 0] } }],
+        },
+      },
+    ],
+  };
+  assert.deepEqual(stackedTRS(b).translation, [5, 6, 7]);
+});
+
+test("decomposeMatrix recovers translation, rotation and scale", () => {
+  // 90° about Z, scale 2, translated
+  const m = [0, 2, 0, 0, -2, 0, 0, 0, 0, 0, 2, 0, 1, 2, 3, 1];
+  const d = decomposeMatrix(m);
+  assert.deepEqual(d.translation, [1, 2, 3]);
+  for (const s of d.scale) assert.ok(Math.abs(s - 2) < 1e-6);
+  assert.ok(Math.abs(Math.hypot(...d.rotation) - 1) < 1e-6);
+  assert.ok(Math.abs(Math.abs(d.rotation[2]) - Math.SQRT1_2) < 1e-6);
+});

--- a/test/textures.test.js
+++ b/test/textures.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { pickBestImage } from "../lib/sf-api.js";
+import { isDescramblable, pickBestImage } from "../lib/sf-api.js";
 
 function im(w, h, extra = {}) {
   return { width: w, height: h, url: `${w}.jpg`, size: w * h, ...extra };
@@ -43,4 +43,78 @@ test("same resolution prefers PNG over JPEG", () => {
     im(2048, 2048, { url: "a.png", size: 800000 }),
   ]);
   assert.ok(best.url.endsWith(".png"));
+});
+
+// --- texture protection: only power-of-two variants can be descrambled ---
+
+test("a protected map that is not power-of-two loses to one that is", () => {
+  const best = pickBestImage([
+    { width: 800, height: 100, url: "orig.png", size: 12510, pk: 46634 },
+    { width: 512, height: 64, url: "pot.png", size: 23906, pk: 46634 },
+  ]);
+  assert.equal(best.width, 512);
+});
+
+test("the raw original is skipped even when it is a multiple of 8", () => {
+  // 1600x200 and 8000x1000 are both 8px-aligned but neither is power-of-two,
+  // and neither descrambles.
+  assert.equal(pickBestImage([
+    { width: 1600, height: 200, url: "a.png", size: 10, pk: 7 },
+    { width: 1024, height: 128, url: "b.png", size: 10, pk: 7 },
+  ]).width, 1024);
+  assert.equal(pickBestImage([
+    { width: 8000, height: 1000, url: "a.png", size: 10, pk: 7 },
+    { width: 4096, height: 512, url: "b.png", size: 10, pk: 7 },
+  ]).width, 4096);
+});
+
+test("unprotected maps are kept whatever their size", () => {
+  const best = pickBestImage([
+    { width: 800, height: 100, url: "big.png", size: 100, pk: null },
+    { width: 512, height: 64, url: "small.png", size: 100, pk: null },
+  ]);
+  assert.equal(best.width, 800);
+});
+
+test("all-unusable protected maps still return the largest rather than nothing", () => {
+  const best = pickBestImage([
+    { width: 800, height: 100, url: "a.png", size: 10, pk: 1 },
+    { width: 400, height: 50, url: "b.png", size: 10, pk: 1 },
+  ]);
+  assert.equal(best.width, 800);
+});
+
+test("a texture-level key still protects variants that omit their own", () => {
+  const best = pickBestImage(
+    [
+      { width: 800, height: 100, url: "big.png", size: 10 },
+      { width: 512, height: 64, url: "small.png", size: 10 },
+    ],
+    0,
+    46634
+  );
+  assert.equal(best.width, 512);
+});
+
+test("maxEdge still applies within the descramblable maps", () => {
+  const best = pickBestImage(
+    [
+      { width: 4096, height: 512, url: "a.png", size: 10, pk: 7 },
+      { width: 2048, height: 256, url: "b.png", size: 10, pk: 7 },
+      { width: 512, height: 64, url: "c.png", size: 10, pk: 7 },
+    ],
+    2048
+  );
+  assert.equal(best.width, 2048);
+});
+
+test("isDescramblable accepts only power-of-two protected maps", () => {
+  assert.equal(isDescramblable({ width: 2048, height: 256, pk: 5 }), true);
+  assert.equal(isDescramblable({ width: 4096, height: 512, pk: 5 }), true);
+  assert.equal(isDescramblable({ width: 8000, height: 1000, pk: 5 }), false);
+  assert.equal(isDescramblable({ width: 1600, height: 200, pk: 5 }), false);
+  assert.equal(isDescramblable({ width: 800, height: 100, pk: 5 }), false);
+  assert.equal(isDescramblable({ width: 1600, height: 201, pk: 5 }), false);
+  // no key means it was never scrambled, so size does not matter
+  assert.equal(isDescramblable({ width: 800, height: 100, pk: null }), true);
 });

--- a/test/uv-sets.test.js
+++ b/test/uv-sets.test.js
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { uvQuantBox } from "../lib/osgjs2gltf.js";
+
+/**
+ * Metadata as Sketchfab actually writes it for a mesh whose material carries
+ * five textures: the UV attributes are TexCoord1/3/5/7/8, every unit gets a
+ * bits+mode pair, and only the first gets a bounding box. Values are from a
+ * model whose materials span eight texture units.
+ */
+const FIVE_UNIT_META = {
+  attributes: 4,
+  uv_0_mode: 0,
+  uv_1_bbl_x: -1.98682e-8, uv_1_bbl_y: 0,
+  uv_1_h_x: 0.000122085, uv_1_h_y: 0.000122085,
+  uv_1_bits: 14, uv_1_mode: 3,
+  uv_2_mode: 0,
+  uv_3_bits: 14, uv_3_mode: 3,
+  uv_4_mode: 0,
+  uv_5_bits: 14, uv_5_mode: 3,
+  uv_6_mode: 0,
+  uv_7_bits: 14, uv_7_mode: 3,
+  uv_8_bits: 14, uv_8_mode: 3,
+};
+
+test("uvQuantBox uses a unit's own box when it has one", () => {
+  const box = uvQuantBox(FIVE_UNIT_META, "1");
+  assert.deepEqual(box.bbl, [-1.98682e-8, 0]);
+  assert.deepEqual(box.h, [0.000122085, 0.000122085]);
+});
+
+test("uvQuantBox falls back to the first boxed unit for later sets", () => {
+  // Units 3/5/7/8 carry bits+mode but no box. Without the fallback they skip
+  // dequantization and ship as raw 14-bit integers, ~8191x too large.
+  for (const unit of ["3", "5", "7", "8"]) {
+    const box = uvQuantBox(FIVE_UNIT_META, unit);
+    assert.ok(box, `unit ${unit} must resolve a box`);
+    assert.deepEqual(box.h, [0.000122085, 0.000122085]);
+  }
+});
+
+test("uvQuantBox picks the lowest boxed unit, not the first key seen", () => {
+  // Key order is not numeric order, and JS object key order puts uv_12_ before
+  // uv_3_ under a lexicographic sort.
+  const meta = {
+    uv_12_bbl_x: 5, uv_12_bbl_y: 5, uv_12_h_x: 9, uv_12_h_y: 9,
+    uv_3_bbl_x: 0, uv_3_bbl_y: 0, uv_3_h_x: 1, uv_3_h_y: 1,
+    uv_18_mode: 3,
+  };
+  assert.deepEqual(uvQuantBox(meta, "18").h, [1, 1]);
+});
+
+test("uvQuantBox returns null when no unit carries a box", () => {
+  assert.equal(uvQuantBox({ uv_1_bits: 14, uv_1_mode: 3 }, "1"), null);
+});

--- a/test/uv-sets.test.js
+++ b/test/uv-sets.test.js
@@ -53,3 +53,37 @@ test("uvQuantBox picks the lowest boxed unit, not the first key seen", () => {
 test("uvQuantBox returns null when no unit carries a box", () => {
   assert.equal(uvQuantBox({ uv_1_bits: 14, uv_1_mode: 3 }, "1"), null);
 });
+
+/* --- texture unit -> glTF texCoord -------------------------------------- */
+import { texCoordsForGeometry } from "../lib/osgjs2gltf.js";
+
+test("texCoordsForGeometry leaves single-UV meshes alone", () => {
+  // The common case by a wide margin: one UV set, so every binding is index 0
+  // and the material cache key must not change.
+  const map = { uvUnits: { albedo: 1, normal: 1 } };
+  assert.deepEqual(texCoordsForGeometry(map, [1]), {});
+});
+
+test("texCoordsForGeometry maps a sparse unit onto its dense index", () => {
+  // M17_TwoUVSets on r3_01: albedo samples unit 1, the lightmap samples unit 3,
+  // and the mesh carries TexCoord1 + TexCoord3 -> TEXCOORD_0 + TEXCOORD_1.
+  const map = { uvUnits: { albedo: 1, emissive: 3 } };
+  assert.deepEqual(texCoordsForGeometry(map, [1, 3]), { emissive: 1 });
+});
+
+test("texCoordsForGeometry handles multi-digit units in numeric order", () => {
+  const map = { uvUnits: { albedo: 3, normal: 12, emissive: 18 } };
+  assert.deepEqual(texCoordsForGeometry(map, [3, 12, 18]), { normal: 1, emissive: 2 });
+});
+
+test("texCoordsForGeometry falls back to 0 for a unit with no UV data", () => {
+  // A channel can name a unit the geometry never supplied. Index 0 is the only
+  // safe answer -- a dangling texCoord would reference a missing accessor.
+  const map = { uvUnits: { albedo: 1, emissive: 9 } };
+  assert.deepEqual(texCoordsForGeometry(map, [1, 3]), {});
+});
+
+test("texCoordsForGeometry ignores roles with no recorded unit", () => {
+  const map = { uvUnits: { albedo: 1, normal: undefined } };
+  assert.deepEqual(texCoordsForGeometry(map, [1, 3]), {});
+});

--- a/test/uv-transforms.test.js
+++ b/test/uv-transforms.test.js
@@ -1,0 +1,93 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { khrTextureTransform } from "../lib/osgjs2gltf.js";
+
+/**
+ * Sketchfab's viewer computes `uv' = mat2(UVTransforms) * uv + UVOffset` and
+ * fills that column-major mat2 with vec4(cos*sx, -sin*sy, sin*sx, cos*sy),
+ * i.e. S.R -- rotate, then scale. glTF specifies translation * rotation *
+ * scale, i.e. R.S. Same rotation sign, opposite order.
+ */
+
+test("offset and scale pass straight through", () => {
+  const { ext, exact } = khrTextureTransform({
+    offset: [0.25, 0.5], scale: [2, 3], rotation: 0,
+  });
+  assert.deepEqual(ext.offset, [0.25, 0.5]);
+  assert.deepEqual(ext.scale, [2, 3]);
+  assert.equal(ext.rotation, undefined, "an identity rotation is omitted");
+  assert.equal(exact, true, "with no rotation the two orders agree");
+});
+
+test("a uniform scale with rotation is still exact", () => {
+  // Scalar scaling commutes with rotation, so S.R == R.S.
+  const { ext, exact } = khrTextureTransform({
+    offset: [0, 0], scale: [3, 3], rotation: Math.PI / 4,
+  });
+  assert.equal(ext.rotation, Math.PI / 4);
+  assert.deepEqual(ext.scale, [3, 3]);
+  assert.equal(ext.offset, undefined, "a zero offset is omitted");
+  assert.equal(exact, true);
+});
+
+test("a non-uniform scale with rotation is reported inexact", () => {
+  // M01_Albedo_POT_2048 on r3_01. S.R is a shear no R'.S' equals, so
+  // KHR_texture_transform cannot express it and the caller must be told.
+  const { ext, exact } = khrTextureTransform({
+    offset: [0.25, 0], scale: [2, 1], rotation: Math.PI / 6,
+  });
+  assert.equal(exact, false);
+  assert.deepEqual(ext.scale, [2, 1], "still exported as the closest match");
+  assert.equal(ext.rotation, Math.PI / 6);
+});
+
+test("a mirrored scale is not uniform, equal magnitudes notwithstanding", () => {
+  // [-2, 2] is a reflection times a scale, and reflection does not commute
+  // with rotation: S.R and R.S disagree in the off-diagonal sign.
+  const { exact } = khrTextureTransform({
+    offset: [0, 0], scale: [-2, 2], rotation: 1,
+  });
+  assert.equal(exact, false);
+});
+
+test("an identity transform emits nothing", () => {
+  const { ext } = khrTextureTransform({ offset: [0, 0], scale: [1, 1], rotation: 0 });
+  assert.deepEqual(ext, {});
+});
+
+/* --- the sign convention, checked against the viewer's own matrix -------- */
+
+test("the exported transform reproduces the viewer's matrix when orders agree", () => {
+  // Rebuild Sketchfab's mat2 from its shader code and glTF's R.S from the
+  // spec, and require them equal for the cases we claim are exact.
+  const sketchfab = (sx, sy, r) => {
+    const c = Math.cos(r), s = Math.sin(r);
+    // vec4(c*sx, -s*sy, s*sx, c*sy) read column-major
+    return [c * sx, s * sx, -s * sy, c * sy]; // row-major [m00,m01,m10,m11]
+  };
+  const gltf = (sx, sy, r) => {
+    const c = Math.cos(r), s = Math.sin(r);
+    // rotation [[c, s], [-s, c]] times scale diag(sx, sy)
+    return [c * sx, s * sy, -s * sx, c * sy];
+  };
+  for (const [sx, sy, r] of [[2, 3, 0], [3, 3, 0.7], [1, 1, 1.2], [-2, -2, 0.4], [-2, 2, 0.4]]) {
+    const a = sketchfab(sx, sy, r), b = gltf(sx, sy, r);
+    const { exact } = khrTextureTransform({ offset: [0, 0], scale: [sx, sy], rotation: r });
+    if (!exact) continue;
+    for (let i = 0; i < 4; i++) {
+      assert.ok(
+        Math.abs(a[i] - b[i]) < 1e-12,
+        `scale [${sx},${sy}] rot ${r}: element ${i} ${a[i]} vs ${b[i]}`
+      );
+    }
+  }
+});
+
+test("the inexact case really does differ, so the warning is not noise", () => {
+  const c = Math.cos(Math.PI / 6), s = Math.sin(Math.PI / 6);
+  const sx = 2, sy = 1;
+  const sketchfab = [c * sx, s * sx, -s * sy, c * sy];
+  const gltf = [c * sx, s * sy, -s * sx, c * sy];
+  const differs = sketchfab.some((v, i) => Math.abs(v - gltf[i]) > 1e-9);
+  assert.ok(differs, "S.R and R.S must actually diverge here");
+});


### PR DESCRIPTION
> **Follows #6** — please review #4, #5 and #6 first.
>
> Opened against `main` for the same reason as the others; once they merge this diff becomes just the six commits below.

Geometry and material state that was being flattened to a default.

**Take sided-ness from the viewer instead of forcing double.** Every material was emitted `doubleSided: true`. The viewer's `cullFace` says which are actually single-sided.

**Record why animation interpolation is unconditionally LINEAR.** Comment only, no code change. Sketchfab's channel type names encode their interpolation, and every variant it ships is a LERP or SLERP — step curves are converted on import and never arrive. Worth writing down, because the code looks like a missing feature otherwise.

**Keep unused roles out of the material cache key.** The key included roles the material never used, so identical materials were cached separately. On one model this collapsed 18 materials to 10 with no change to the real texture path.

**Keep vertex colour when it is actually painted.** `COLOR_0` was dropped entirely. It is now kept when the colours vary, and skipped when the array is a single constant tint — which is what Sketchfab writes for most meshes, and which would otherwise multiply a flat colour over every texture.

**Label vertex and index bufferViews with their GL target.** 197 validator hints, zero behaviour change.

**Convert line geometry instead of mistaking it for a wireframe overlay.** Authored lines were dropped. Three separate things had to change: the primitive loop rejected mode LINES; the wireframe filter treated *any* LINES primitive as the viewer's overlay, so supporting lines without fixing it would have given every mesh an edge-only duplicate; and the untextured-shell heuristic matched a material named `Lines` against its `hair|line|brow|lash` name guess. That guess is now scoped to triangles.

Worth noting for anyone extending this: Sketchfab flattens `LINE_STRIP` and `LINE_LOOP` to plain segments on import, so glTF modes 2 and 3 never need to be produced.

### Testing

`npm test` — 162 passing, up from 151 on #6.
